### PR TITLE
Feature/fz 54 reservation page

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,13 +1,28 @@
 <script setup>
-import { RouterLink, RouterView } from 'vue-router'
+import { RouterLink, RouterView, useRoute } from 'vue-router'
+import { computed } from 'vue'
 
 import AppNav from './components/layout/AppNav.vue';
+
+const route = useRoute()
+
+// 네비게이션 바를 숨길 페이지들
+const hideNavPages = [
+  '/fan-meeting/',
+  '/seat-select/',
+  '/payment/',
+  '/payment-success'
+]
+
+const shouldShowNav = computed(() => {
+  return !hideNavPages.some(page => route.path.includes(page))
+})
 </script>
 
 <template>
    <div class="w-full max-w-[393px] md:max-w-[430px] mx-auto">
     <router-view />
-    <app-nav></app-nav>
+    <app-nav v-if="shouldShowNav"></app-nav>
   </div>
 </template> 
 

--- a/src/pages/FanMeetingDetailPage.vue
+++ b/src/pages/FanMeetingDetailPage.vue
@@ -1,19 +1,166 @@
 <template>
-    <div class="p-4">
-      <h1 class="text-xl font-bold mb-4">팬미팅 상세 페이지</h1>
-      <!-- 추후 상세 정보 영역 구성 -->
-      <p>이곳에 팬미팅 상세 내용을 표시합니다.</p>
+  <div class="w-full min-h-screen bg-white">
+    <!-- Header -->
+    <div class="flex items-center justify-between p-4 bg-white">
+      <button @click="goBack" class="p-2">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <path d="M15 18L9 12L15 6" stroke="#000000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+        </svg>
+      </button>
+      <h1 class="text-lg font-semibold text-black">팬미팅 상세</h1>
+      <div class="w-6"></div>
     </div>
-  </template>
-  
-  <script setup>
-  // 향후 팬미팅 id 등을 가져와 처리할 수 있도록 준비
-  import { useRoute } from 'vue-router'
-  
-  const route = useRoute()
-  // const fanMeetingId = route.params.id // 추후 필요 시 사용
-  </script>
-  
-  <style scoped>
-  /* 추후 상세 페이지 스타일링 여기에 추가 */
-  </style>
+
+    <!-- Main Content -->
+    <div class="px-4 pb-32">
+      <!-- Fan Meeting Image -->
+      <div class="w-full h-64 bg-gradient-to-br from-purple-400 to-pink-500 rounded-lg mb-6 overflow-hidden">
+        <div class="w-full h-full flex items-center justify-center">
+          <div class="text-center text-white">
+            <h2 class="text-2xl font-bold mb-2">{{ fanMeetingInfo.title }}</h2>
+            <p class="text-lg opacity-90">{{ fanMeetingInfo.subtitle }}</p>
+          </div>
+        </div>
+      </div>
+
+      <!-- Fan Meeting Info -->
+      <div class="space-y-6">
+        <!-- Title -->
+        <div>
+          <h3 class="text-xl font-bold text-black mb-2">{{ fanMeetingInfo.title }}</h3>
+          <p class="text-gray-600">{{ fanMeetingInfo.subtitle }}</p>
+        </div>
+
+        <!-- Details -->
+        <div class="space-y-4">
+          <!-- Date -->
+          <div class="flex items-center">
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" class="mr-3">
+              <rect x="3" y="4" width="18" height="18" rx="2" ry="2" stroke="#6B7280" stroke-width="2"/>
+              <line x1="16" y1="2" x2="16" y2="6" stroke="#6B7280" stroke-width="2"/>
+              <line x1="8" y1="2" x2="8" y2="6" stroke="#6B7280" stroke-width="2"/>
+              <line x1="3" y1="10" x2="21" y2="10" stroke="#6B7280" stroke-width="2"/>
+            </svg>
+            <div>
+              <p class="text-sm text-gray-500">일시</p>
+              <p class="text-base font-semibold text-black">{{ fanMeetingInfo.date }}</p>
+            </div>
+          </div>
+
+          <!-- Venue -->
+          <div class="flex items-center">
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" class="mr-3">
+              <path d="M21 10C21 17 12 23 12 23S3 17 3 10C3 5.02944 7.02944 1 12 1C16.9706 1 21 5.02944 21 10Z" stroke="#6B7280" stroke-width="2"/>
+              <circle cx="12" cy="10" r="3" stroke="#6B7280" stroke-width="2"/>
+            </svg>
+            <div>
+              <p class="text-sm text-gray-500">장소</p>
+              <p class="text-base font-semibold text-black">{{ fanMeetingInfo.venue }}</p>
+            </div>
+          </div>
+
+          <!-- Price -->
+          <div class="flex items-center">
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" class="mr-3">
+              <line x1="12" y1="1" x2="12" y2="23" stroke="#6B7280" stroke-width="2"/>
+              <path d="M17 5H9.5C8.11929 5 7 6.11929 7 7.5C7 8.88071 8.11929 10 9.5 10H14.5C15.8807 10 17 11.1193 17 12.5C17 13.8807 15.8807 15 14.5 15H7" stroke="#6B7280" stroke-width="2"/>
+            </svg>
+            <div>
+              <p class="text-sm text-gray-500">가격</p>
+              <p class="text-base font-semibold text-black">{{ fanMeetingInfo.price }}원</p>
+            </div>
+          </div>
+        </div>
+
+        <!-- Description -->
+        <div>
+          <h4 class="text-lg font-semibold text-black mb-3">상세 정보</h4>
+          <p class="text-gray-700 leading-relaxed">{{ fanMeetingInfo.description }}</p>
+        </div>
+      </div>
+    </div>
+
+    <!-- Reservation Button -->
+    <div class="fixed bottom-20 left-0 right-0 bg-white border-t border-gray-200 p-4">
+      <div class="max-w-sm mx-auto px-4">
+        <button 
+          @click="goToSeatSelection"
+          class="w-full bg-brand-primary text-black py-4 rounded-lg font-semibold hover:bg-brand-accent transition-colors"
+        >
+          예매하기
+        </button>
+      </div>
+    </div>
+
+    <!-- Spacer for fixed button -->
+    <div class="h-32"></div>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, onMounted } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+
+const route = useRoute()
+const router = useRouter()
+
+const fanMeetingId = computed(() => route.params.id)
+
+// 팬미팅 정보 (실제로는 API에서 가져올 데이터)
+const fanMeetingInfo = ref({
+  id: 1,
+  title: '2025 여단오 팬미팅',
+  subtitle: '내가 제일 예뻐',
+  date: '2025년 2월 14일 (금) 19:00',
+  venue: '올림픽공원 올림픽홀',
+  price: '99,000',
+  description: '여단오와 함께하는 특별한 시간! 다양한 이벤트와 소통의 시간이 준비되어 있습니다. 팬들과의 만남을 통해 더욱 가까워질 수 있는 소중한 기회입니다.'
+})
+
+// 팬미팅 ID에 따른 정보 설정
+const fanMeetingData = {
+  1: {
+    title: '2025 태요미네 팬미팅',
+    subtitle: '함께하는 특별한 시간',
+    date: '2025년 1월 20일 (월) 19:00',
+    venue: '성동구 문화회관',
+    price: '89,000'
+  },
+  2: {
+    title: '2025 여단오 팬미팅',
+    subtitle: '내가 제일 예뻐',
+    date: '2025년 2월 14일 (금) 19:00',
+    venue: '올림픽공원 올림픽홀',
+    price: '99,000'
+  },
+  3: {
+    title: '2025 침착맨 팬미팅',
+    subtitle: '침착하게 만나요',
+    date: '2025년 3월 10일 (월) 18:00',
+    venue: '마포아트센터',
+    price: '79,000'
+  }
+}
+
+onMounted(() => {
+  const id = fanMeetingId.value
+  if (fanMeetingData[id]) {
+    fanMeetingInfo.value = {
+      ...fanMeetingInfo.value,
+      ...fanMeetingData[id]
+    }
+  }
+})
+
+const goBack = () => {
+  router.back()
+}
+
+const goToSeatSelection = () => {
+  router.push(`/seat-select/${fanMeetingId.value}`)
+}
+</script>
+
+<style scoped>
+/* 추가 스타일링이 필요한 경우 여기에 작성 */
+</style>

--- a/src/pages/FanMeetingDetailPage.vue
+++ b/src/pages/FanMeetingDetailPage.vue
@@ -1,91 +1,53 @@
 <template>
   <div class="w-full min-h-screen bg-white">
-    <!-- Header -->
-    <div class="flex items-center justify-between p-4 bg-white">
-      <button @click="goBack" class="p-2">
-        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-          <path d="M15 18L9 12L15 6" stroke="#000000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-        </svg>
-      </button>
-      <h1 class="text-lg font-semibold text-black">팬미팅 상세</h1>
-      <div class="w-6"></div>
+    <!-- Back Button (Top Left) -->
+    <div class="w-full max-w-[393px] md:max-w-[430px] mx-auto relative">
+      <div class="absolute top-6 left-6 z-10">
+        <button @click="goBack" class="p-2">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <path d="M15 18L9 12L15 6" stroke="#000000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+          </svg>
+        </button>
+      </div>
     </div>
 
-    <!-- Main Content -->
-    <div class="px-4 pb-32">
-      <!-- Fan Meeting Image -->
-      <div class="w-full h-64 bg-gradient-to-br from-purple-400 to-pink-500 rounded-lg mb-6 overflow-hidden">
-        <div class="w-full h-full flex items-center justify-center">
-          <div class="text-center text-white">
-            <h2 class="text-2xl font-bold mb-2">{{ fanMeetingInfo.title }}</h2>
-            <p class="text-lg opacity-90">{{ fanMeetingInfo.subtitle }}</p>
+    <!-- Main Content Container -->
+    <div class="w-full max-w-[393px] md:max-w-[430px] mx-auto">
+      <!-- Influencer Profile -->
+      <div class="px-6 pt-20 pb-4">
+        <div class="flex items-center">
+          <div :class="`w-16 h-16 rounded-full bg-gradient-to-br ${fanMeetingData.bgColor} overflow-hidden mr-4`">
+            <div class="w-full h-full flex items-center justify-center">
+              <span class="text-white font-bold text-xl">{{ fanMeetingData.initial }}</span>
+            </div>
+          </div>
+          <div>
+            <h1 class="text-xl font-bold text-black">{{ fanMeetingData.name }}</h1>
           </div>
         </div>
       </div>
 
-      <!-- Fan Meeting Info -->
-      <div class="space-y-6">
-        <!-- Title -->
-        <div>
-          <h3 class="text-xl font-bold text-black mb-2">{{ fanMeetingInfo.title }}</h3>
-          <p class="text-gray-600">{{ fanMeetingInfo.subtitle }}</p>
-        </div>
-
-        <!-- Details -->
-        <div class="space-y-4">
-          <!-- Date -->
-          <div class="flex items-center">
-            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" class="mr-3">
-              <rect x="3" y="4" width="18" height="18" rx="2" ry="2" stroke="#6B7280" stroke-width="2"/>
-              <line x1="16" y1="2" x2="16" y2="6" stroke="#6B7280" stroke-width="2"/>
-              <line x1="8" y1="2" x2="8" y2="6" stroke="#6B7280" stroke-width="2"/>
-              <line x1="3" y1="10" x2="21" y2="10" stroke="#6B7280" stroke-width="2"/>
-            </svg>
-            <div>
-              <p class="text-sm text-gray-500">일시</p>
-              <p class="text-base font-semibold text-black">{{ fanMeetingInfo.date }}</p>
+      <!-- Poster -->
+      <div class="px-6 pb-24">
+        <div class="w-full aspect-[3/4] bg-gradient-to-br from-purple-400 to-pink-500 rounded-lg overflow-hidden flex items-center justify-center">
+          <div class="text-center text-white">
+            <h2 class="text-2xl font-bold mb-2">{{ fanMeetingData.title }}</h2>
+            <p class="text-lg opacity-90">{{ fanMeetingData.subtitle }}</p>
+            <div class="mt-4 text-sm opacity-80">
+              <p>{{ fanMeetingData.date }}</p>
+              <p>{{ fanMeetingData.venue }}</p>
             </div>
           </div>
-
-          <!-- Venue -->
-          <div class="flex items-center">
-            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" class="mr-3">
-              <path d="M21 10C21 17 12 23 12 23S3 17 3 10C3 5.02944 7.02944 1 12 1C16.9706 1 21 5.02944 21 10Z" stroke="#6B7280" stroke-width="2"/>
-              <circle cx="12" cy="10" r="3" stroke="#6B7280" stroke-width="2"/>
-            </svg>
-            <div>
-              <p class="text-sm text-gray-500">장소</p>
-              <p class="text-base font-semibold text-black">{{ fanMeetingInfo.venue }}</p>
-            </div>
-          </div>
-
-          <!-- Price -->
-          <div class="flex items-center">
-            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" class="mr-3">
-              <line x1="12" y1="1" x2="12" y2="23" stroke="#6B7280" stroke-width="2"/>
-              <path d="M17 5H9.5C8.11929 5 7 6.11929 7 7.5C7 8.88071 8.11929 10 9.5 10H14.5C15.8807 10 17 11.1193 17 12.5C17 13.8807 15.8807 15 14.5 15H7" stroke="#6B7280" stroke-width="2"/>
-            </svg>
-            <div>
-              <p class="text-sm text-gray-500">가격</p>
-              <p class="text-base font-semibold text-black">{{ fanMeetingInfo.price }}원</p>
-            </div>
-          </div>
-        </div>
-
-        <!-- Description -->
-        <div>
-          <h4 class="text-lg font-semibold text-black mb-3">상세 정보</h4>
-          <p class="text-gray-700 leading-relaxed">{{ fanMeetingInfo.description }}</p>
         </div>
       </div>
     </div>
 
     <!-- Reservation Button -->
-    <div class="fixed bottom-20 left-0 right-0 bg-white border-t border-gray-200 p-4">
+    <div class="fixed bottom-0 left-0 right-0 bg-white border-t border-gray-200 p-4">
       <div class="max-w-sm mx-auto px-4">
         <button 
           @click="goToSeatSelection"
-          class="w-full bg-brand-primary text-black py-4 rounded-lg font-semibold hover:bg-brand-accent transition-colors"
+          class="w-full bg-brand-primary text-black py-4 rounded-xl font-semibold hover:bg-brand-accent transition-colors"
         >
           예매하기
         </button>
@@ -93,12 +55,12 @@
     </div>
 
     <!-- Spacer for fixed button -->
-    <div class="h-32"></div>
+    <div class="h-20"></div>
   </div>
 </template>
 
 <script setup>
-import { ref, computed, onMounted } from 'vue'
+import { computed } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 
 const route = useRoute()
@@ -106,50 +68,84 @@ const router = useRouter()
 
 const fanMeetingId = computed(() => route.params.id)
 
-// 팬미팅 정보 (실제로는 API에서 가져올 데이터)
-const fanMeetingInfo = ref({
-  id: 1,
-  title: '2025 여단오 팬미팅',
-  subtitle: '내가 제일 예뻐',
-  date: '2025년 2월 14일 (금) 19:00',
-  venue: '올림픽공원 올림픽홀',
-  price: '99,000',
-  description: '여단오와 함께하는 특별한 시간! 다양한 이벤트와 소통의 시간이 준비되어 있습니다. 팬들과의 만남을 통해 더욱 가까워질 수 있는 소중한 기회입니다.'
-})
-
-// 팬미팅 ID에 따른 정보 설정
-const fanMeetingData = {
+// 인플루언서별 팬미팅 데이터
+const fanMeetingDataMap = {
   1: {
+    name: '태요미네',
     title: '2025 태요미네 팬미팅',
     subtitle: '함께하는 특별한 시간',
-    date: '2025년 1월 20일 (월) 19:00',
+    date: '2025.01.20 (월) 19:00',
     venue: '성동구 문화회관',
-    price: '89,000'
+    initial: '태',
+    bgColor: 'from-pink-400 to-purple-500'
   },
   2: {
+    name: '여단오',
     title: '2025 여단오 팬미팅',
     subtitle: '내가 제일 예뻐',
-    date: '2025년 2월 14일 (금) 19:00',
+    date: '2025.02.14 (금) 19:00',
     venue: '올림픽공원 올림픽홀',
-    price: '99,000'
+    initial: '여',
+    bgColor: 'from-blue-400 to-cyan-500'
   },
   3: {
+    name: '침착맨',
     title: '2025 침착맨 팬미팅',
     subtitle: '침착하게 만나요',
-    date: '2025년 3월 10일 (월) 18:00',
+    date: '2025.03.10 (월) 18:00',
     venue: '마포아트센터',
-    price: '79,000'
+    initial: '침',
+    bgColor: 'from-green-400 to-emerald-500'
+  },
+  4: {
+    name: '토모토모',
+    title: '2025 토모토모 팬미팅',
+    subtitle: '토모토모와 함께',
+    date: '2025.04.05 (토) 19:00',
+    venue: '부산문화회관',
+    initial: '토',
+    bgColor: 'from-orange-400 to-red-500'
+  },
+  5: {
+    name: '찰스엔터',
+    title: '2025 찰스엔터 팬미팅',
+    subtitle: '엔터테인먼트 타임',
+    date: '2025.04.12 (토) 18:00',
+    venue: '강남아트센터',
+    initial: '찰',
+    bgColor: 'from-purple-400 to-indigo-500'
+  },
+  6: {
+    name: '뭐랭하맨',
+    title: '2025 뭐랭하맨 팬미팅',
+    subtitle: '뭐랭하는 시간',
+    date: '2025.04.19 (토) 19:30',
+    venue: '강남CGV',
+    initial: '뭐',
+    bgColor: 'from-yellow-400 to-orange-500'
+  },
+  7: {
+    name: '빠더너스 BDNS',
+    title: '2025 빠더너스 팬미팅',
+    subtitle: 'BDNS와 함께',
+    date: '2025.04.26 (토) 18:30',
+    venue: '강남스타일홀',
+    initial: '빠',
+    bgColor: 'from-teal-400 to-blue-500'
+  },
+  8: {
+    name: '쯔양',
+    title: '2025 쯔양 팬미팅',
+    subtitle: '먹방과 소통',
+    date: '2025.05.03 (토) 19:00',
+    venue: '강남맛집홀',
+    initial: '쯔',
+    bgColor: 'from-rose-400 to-pink-500'
   }
 }
 
-onMounted(() => {
-  const id = fanMeetingId.value
-  if (fanMeetingData[id]) {
-    fanMeetingInfo.value = {
-      ...fanMeetingInfo.value,
-      ...fanMeetingData[id]
-    }
-  }
+const fanMeetingData = computed(() => {
+  return fanMeetingDataMap[fanMeetingId.value] || fanMeetingDataMap[1]
 })
 
 const goBack = () => {

--- a/src/pages/FanMeetingPage.vue
+++ b/src/pages/FanMeetingPage.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="w-full min-h-screen bg-white">
     <!-- Header -->
-    <div class="flex items-center justify-between p-4 bg-white">
+    <div class="flex items-center justify-between p-4 bg-white border-b border-gray-200">
       <button @click="goBack" class="p-2">
         <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
           <path d="M15 18L9 12L15 6" stroke="#000000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
@@ -14,171 +14,47 @@
     <!-- Search Bar -->
     <div class="px-4 mb-6">
       <div class="flex items-center bg-gray-50 rounded-2xl px-4 py-3 border border-gray-200">
-        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-          <circle cx="11" cy="11" r="8" stroke="#9CA3AF" stroke-width="2"/>
-          <path d="21 21L16.65 16.65" stroke="#9CA3AF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-        </svg>
         <input 
           type="text" 
           placeholder="검색어를 입력해주세요." 
-          class="ml-3 bg-transparent flex-1 text-gray-700 placeholder-gray-400 outline-none"
+          class="bg-transparent flex-1 text-gray-700 placeholder-gray-400 outline-none"
           v-model="searchQuery"
         />
+        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <circle cx="11" cy="11" r="8" stroke="#808080" stroke-width="2" fill="none"/>
+          <path d="m21 21-4.35-4.35" stroke="#808080" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+        </svg>
       </div>
     </div>
 
     <!-- Influencer List -->
-    <div class="px-9 space-y-6 pb-24">
-      <!-- 태요미네 -->
-      <div class="flex items-center cursor-pointer" @click="goToDetail(1)">
-        <div class="w-16 h-16 rounded-full bg-gradient-to-br from-pink-400 to-purple-500 overflow-hidden mr-6">
+    <div class="px-4 space-y-6 pb-24">
+      <div 
+        v-for="influencer in filteredInfluencers" 
+        :key="influencer.id"
+        class="flex items-center cursor-pointer" 
+        @click="goToDetail(influencer.id)"
+      >
+        <div :class="`w-16 h-16 rounded-full bg-gradient-to-br ${influencer.bgColor} overflow-hidden mr-6`">
           <div class="w-full h-full flex items-center justify-center">
-            <span class="text-white font-bold text-lg">태</span>
+            <span class="text-white font-bold text-lg">{{ influencer.initial }}</span>
           </div>
         </div>
         <div class="flex-1">
-          <h3 class="text-xl font-semibold text-black mb-1">태요미네</h3>
+          <h3 class="text-xl font-semibold text-black mb-1">{{ influencer.name }}</h3>
           <div class="flex items-center text-gray-500 text-base">
             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
               <path d="M21 10C21 17 12 23 12 23S3 17 3 10C3 5.02944 7.02944 1 12 1C16.9706 1 21 5.02944 21 10Z" stroke="#808080" stroke-width="1.5"/>
               <circle cx="12" cy="10" r="3" stroke="#808080" stroke-width="1.5"/>
             </svg>
-            <span class="ml-2">서울시 성동구</span>
+            <span class="ml-2 text-gray-400">{{ influencer.location }}</span>
           </div>
         </div>
       </div>
 
-      <!-- 여단오 -->
-      <div class="flex items-center cursor-pointer" @click="goToDetail(2)">
-        <div class="w-16 h-16 rounded-full bg-gradient-to-br from-blue-400 to-cyan-500 overflow-hidden mr-6">
-          <div class="w-full h-full flex items-center justify-center">
-            <span class="text-white font-bold text-lg">여</span>
-          </div>
-        </div>
-        <div class="flex-1">
-          <h3 class="text-xl font-semibold text-black mb-1">여단오</h3>
-          <div class="flex items-center text-gray-500 text-base">
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-              <path d="M21 10C21 17 12 23 12 23S3 17 3 10C3 5.02944 7.02944 1 12 1C16.9706 1 21 5.02944 21 10Z" stroke="#808080" stroke-width="1.5"/>
-              <circle cx="12" cy="10" r="3" stroke="#808080" stroke-width="1.5"/>
-            </svg>
-            <span class="ml-2">서울시 마포구</span>
-          </div>
-        </div>
-      </div>
-
-      <!-- 침착맨 -->
-      <div class="flex items-center cursor-pointer" @click="goToDetail(3)">
-        <div class="w-16 h-16 rounded-full bg-gradient-to-br from-green-400 to-emerald-500 overflow-hidden mr-6">
-          <div class="w-full h-full flex items-center justify-center">
-            <span class="text-white font-bold text-lg">침</span>
-          </div>
-        </div>
-        <div class="flex-1">
-          <h3 class="text-xl font-semibold text-black mb-1">침착맨</h3>
-          <div class="flex items-center text-gray-500 text-base">
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-              <path d="M21 10C21 17 12 23 12 23S3 17 3 10C3 5.02944 7.02944 1 12 1C16.9706 1 21 5.02944 21 10Z" stroke="#808080" stroke-width="1.5"/>
-              <circle cx="12" cy="10" r="3" stroke="#808080" stroke-width="1.5"/>
-            </svg>
-            <span class="ml-2">서울시 마포구</span>
-          </div>
-        </div>
-      </div>
-
-      <!-- 토모토모 -->
-      <div class="flex items-center cursor-pointer" @click="goToDetail(4)">
-        <div class="w-16 h-16 rounded-full bg-gradient-to-br from-orange-400 to-red-500 overflow-hidden mr-6">
-          <div class="w-full h-full flex items-center justify-center">
-            <span class="text-white font-bold text-lg">토</span>
-          </div>
-        </div>
-        <div class="flex-1">
-          <h3 class="text-xl font-semibold text-black mb-1">토모토모</h3>
-          <div class="flex items-center text-gray-500 text-base">
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-              <path d="M21 10C21 17 12 23 12 23S3 17 3 10C3 5.02944 7.02944 1 12 1C16.9706 1 21 5.02944 21 10Z" stroke="#808080" stroke-width="1.5"/>
-              <circle cx="12" cy="10" r="3" stroke="#808080" stroke-width="1.5"/>
-            </svg>
-            <span class="ml-2">부산광역시 해운대구</span>
-          </div>
-        </div>
-      </div>
-
-      <!-- 찰스엔터 -->
-      <div class="flex items-center cursor-pointer" @click="goToDetail(5)">
-        <div class="w-16 h-16 rounded-full bg-gradient-to-br from-purple-400 to-indigo-500 overflow-hidden mr-6">
-          <div class="w-full h-full flex items-center justify-center">
-            <span class="text-white font-bold text-lg">찰</span>
-          </div>
-        </div>
-        <div class="flex-1">
-          <h3 class="text-xl font-semibold text-black mb-1">찰스엔터</h3>
-          <div class="flex items-center text-gray-500 text-base">
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-              <path d="M21 10C21 17 12 23 12 23S3 17 3 10C3 5.02944 7.02944 1 12 1C16.9706 1 21 5.02944 21 10Z" stroke="#808080" stroke-width="1.5"/>
-              <circle cx="12" cy="10" r="3" stroke="#808080" stroke-width="1.5"/>
-            </svg>
-            <span class="ml-2">서울시 강남구</span>
-          </div>
-        </div>
-      </div>
-
-      <!-- 뭐랭하맨 -->
-      <div class="flex items-center cursor-pointer" @click="goToDetail(6)">
-        <div class="w-16 h-16 rounded-full bg-gradient-to-br from-yellow-400 to-orange-500 overflow-hidden mr-6">
-          <div class="w-full h-full flex items-center justify-center">
-            <span class="text-white font-bold text-lg">뭐</span>
-          </div>
-        </div>
-        <div class="flex-1">
-          <h3 class="text-xl font-semibold text-black mb-1">뭐랭하맨</h3>
-          <div class="flex items-center text-gray-500 text-base">
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-              <path d="M21 10C21 17 12 23 12 23S3 17 3 10C3 5.02944 7.02944 1 12 1C16.9706 1 21 5.02944 21 10Z" stroke="#808080" stroke-width="1.5"/>
-              <circle cx="12" cy="10" r="3" stroke="#808080" stroke-width="1.5"/>
-            </svg>
-            <span class="ml-2">서울시 강남구</span>
-          </div>
-        </div>
-      </div>
-
-      <!-- 빠더너스 BDNS -->
-      <div class="flex items-center cursor-pointer" @click="goToDetail(7)">
-        <div class="w-16 h-16 rounded-full bg-gradient-to-br from-teal-400 to-blue-500 overflow-hidden mr-6">
-          <div class="w-full h-full flex items-center justify-center">
-            <span class="text-white font-bold text-lg">빠</span>
-          </div>
-        </div>
-        <div class="flex-1">
-          <h3 class="text-xl font-semibold text-black mb-1">빠더너스 BDNS</h3>
-          <div class="flex items-center text-gray-500 text-base">
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-              <path d="M21 10C21 17 12 23 12 23S3 17 3 10C3 5.02944 7.02944 1 12 1C16.9706 1 21 5.02944 21 10Z" stroke="#808080" stroke-width="1.5"/>
-              <circle cx="12" cy="10" r="3" stroke="#808080" stroke-width="1.5"/>
-            </svg>
-            <span class="ml-2">서울시 강남구</span>
-          </div>
-        </div>
-      </div>
-
-      <!-- 쯔양 -->
-      <div class="flex items-center cursor-pointer" @click="goToDetail(8)">
-        <div class="w-16 h-16 rounded-full bg-gradient-to-br from-rose-400 to-pink-500 overflow-hidden mr-6">
-          <div class="w-full h-full flex items-center justify-center">
-            <span class="text-white font-bold text-lg">쯔</span>
-          </div>
-        </div>
-        <div class="flex-1">
-          <h3 class="text-xl font-semibold text-black mb-1">쯔양</h3>
-          <div class="flex items-center text-gray-500 text-base">
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-              <path d="M21 10C21 17 12 23 12 23S3 17 3 10C3 5.02944 7.02944 1 12 1C16.9706 1 21 5.02944 21 10Z" stroke="#808080" stroke-width="1.5"/>
-              <circle cx="12" cy="10" r="3" stroke="#808080" stroke-width="1.5"/>
-            </svg>
-            <span class="ml-2">서울시 강남구</span>
-          </div>
-        </div>
+      <!-- 검색 결과가 없을 때 -->
+      <div v-if="filteredInfluencers.length === 0" class="text-center py-12">
+        <p class="text-gray-500">검색 결과가 없습니다.</p>
       </div>
     </div>
   </div>
@@ -191,33 +67,73 @@ import { useRouter } from 'vue-router'
 const router = useRouter()
 const searchQuery = ref('')
 
-// Sample fan meeting data - 실제로는 API에서 가져올 데이터
-const fanMeetings = ref([
+// 인플루언서 데이터
+const influencers = ref([
   {
     id: 1,
-    title: '2025 여단오 팬미팅 \'내가 제일 예뻐\'',
-    venue: '올림픽공원 체조경기장',
-    date: '2025년 8월 15일 (목) 오후 7:00',
-    price: '36,000',
-    image: null
+    name: '태요미네',
+    location: '서울시 성동구',
+    initial: '태',
+    bgColor: 'from-pink-400 to-purple-500'
   },
   {
     id: 2,
-    title: '아이유 팬미팅 \'Through the Night\'',
-    venue: '잠실실내체육관',
-    date: '2025년 9월 20일 (토) 오후 6:00',
-    price: '45,000',
-    image: null
+    name: '여단오',
+    location: '서울시 마포구',
+    initial: '여',
+    bgColor: 'from-blue-400 to-cyan-500'
+  },
+  {
+    id: 3,
+    name: '침착맨',
+    location: '서울시 마포구',
+    initial: '침',
+    bgColor: 'from-green-400 to-emerald-500'
+  },
+  {
+    id: 4,
+    name: '토모토모',
+    location: '부산광역시 해운대구',
+    initial: '토',
+    bgColor: 'from-orange-400 to-red-500'
+  },
+  {
+    id: 5,
+    name: '찰스엔터',
+    location: '서울시 강남구',
+    initial: '찰',
+    bgColor: 'from-purple-400 to-indigo-500'
+  },
+  {
+    id: 6,
+    name: '뭐랭하맨',
+    location: '서울시 강남구',
+    initial: '뭐',
+    bgColor: 'from-yellow-400 to-orange-500'
+  },
+  {
+    id: 7,
+    name: '빠더너스 BDNS',
+    location: '서울시 강남구',
+    initial: '빠',
+    bgColor: 'from-teal-400 to-blue-500'
+  },
+  {
+    id: 8,
+    name: '쯔양',
+    location: '서울시 강남구',
+    initial: '쯔',
+    bgColor: 'from-rose-400 to-pink-500'
   }
 ])
 
-const filteredFanMeetings = computed(() => {
+const filteredInfluencers = computed(() => {
   if (!searchQuery.value) {
-    return fanMeetings.value
+    return influencers.value
   }
-  return fanMeetings.value.filter(fanMeeting => 
-    fanMeeting.title.toLowerCase().includes(searchQuery.value.toLowerCase()) ||
-    fanMeeting.venue.toLowerCase().includes(searchQuery.value.toLowerCase())
+  return influencers.value.filter(influencer => 
+    influencer.name.toLowerCase().includes(searchQuery.value.toLowerCase()) ||
+    influencer.location.toLowerCase().includes(searchQuery.value.toLowerCase())
   )
 })
 
@@ -229,12 +145,4 @@ const goToDetail = (id) => {
   router.push(`/fan-meeting/${id}`)
 }
 
-const goToSeatSelection = (id) => {
-  router.push(`/seat-select/${id}`)
-}
-
-onMounted(() => {
-  // 팬미팅 데이터 로드
-  // fetchFanMeetings()
-})
 </script>

--- a/src/pages/FanMeetingPage.vue
+++ b/src/pages/FanMeetingPage.vue
@@ -1,5 +1,240 @@
 <template>
-    <div class="w-full h-[100vh] flex items-center justify-center text-[24px]">
-      예매하기 페이지
+  <div class="w-full min-h-screen bg-white">
+    <!-- Header -->
+    <div class="flex items-center justify-between p-4 bg-white">
+      <button @click="goBack" class="p-2">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <path d="M15 18L9 12L15 6" stroke="#000000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+        </svg>
+      </button>
+      <h1 class="text-lg font-semibold text-black">예약 페이지</h1>
+      <div class="w-6"></div>
     </div>
-  </template>
+
+    <!-- Search Bar -->
+    <div class="px-4 mb-6">
+      <div class="flex items-center bg-gray-50 rounded-2xl px-4 py-3 border border-gray-200">
+        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <circle cx="11" cy="11" r="8" stroke="#9CA3AF" stroke-width="2"/>
+          <path d="21 21L16.65 16.65" stroke="#9CA3AF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+        </svg>
+        <input 
+          type="text" 
+          placeholder="검색어를 입력해주세요." 
+          class="ml-3 bg-transparent flex-1 text-gray-700 placeholder-gray-400 outline-none"
+          v-model="searchQuery"
+        />
+      </div>
+    </div>
+
+    <!-- Influencer List -->
+    <div class="px-9 space-y-6 pb-24">
+      <!-- 태요미네 -->
+      <div class="flex items-center cursor-pointer" @click="goToDetail(1)">
+        <div class="w-16 h-16 rounded-full bg-gradient-to-br from-pink-400 to-purple-500 overflow-hidden mr-6">
+          <div class="w-full h-full flex items-center justify-center">
+            <span class="text-white font-bold text-lg">태</span>
+          </div>
+        </div>
+        <div class="flex-1">
+          <h3 class="text-xl font-semibold text-black mb-1">태요미네</h3>
+          <div class="flex items-center text-gray-500 text-base">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <path d="M21 10C21 17 12 23 12 23S3 17 3 10C3 5.02944 7.02944 1 12 1C16.9706 1 21 5.02944 21 10Z" stroke="#808080" stroke-width="1.5"/>
+              <circle cx="12" cy="10" r="3" stroke="#808080" stroke-width="1.5"/>
+            </svg>
+            <span class="ml-2">서울시 성동구</span>
+          </div>
+        </div>
+      </div>
+
+      <!-- 여단오 -->
+      <div class="flex items-center cursor-pointer" @click="goToDetail(2)">
+        <div class="w-16 h-16 rounded-full bg-gradient-to-br from-blue-400 to-cyan-500 overflow-hidden mr-6">
+          <div class="w-full h-full flex items-center justify-center">
+            <span class="text-white font-bold text-lg">여</span>
+          </div>
+        </div>
+        <div class="flex-1">
+          <h3 class="text-xl font-semibold text-black mb-1">여단오</h3>
+          <div class="flex items-center text-gray-500 text-base">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <path d="M21 10C21 17 12 23 12 23S3 17 3 10C3 5.02944 7.02944 1 12 1C16.9706 1 21 5.02944 21 10Z" stroke="#808080" stroke-width="1.5"/>
+              <circle cx="12" cy="10" r="3" stroke="#808080" stroke-width="1.5"/>
+            </svg>
+            <span class="ml-2">서울시 마포구</span>
+          </div>
+        </div>
+      </div>
+
+      <!-- 침착맨 -->
+      <div class="flex items-center cursor-pointer" @click="goToDetail(3)">
+        <div class="w-16 h-16 rounded-full bg-gradient-to-br from-green-400 to-emerald-500 overflow-hidden mr-6">
+          <div class="w-full h-full flex items-center justify-center">
+            <span class="text-white font-bold text-lg">침</span>
+          </div>
+        </div>
+        <div class="flex-1">
+          <h3 class="text-xl font-semibold text-black mb-1">침착맨</h3>
+          <div class="flex items-center text-gray-500 text-base">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <path d="M21 10C21 17 12 23 12 23S3 17 3 10C3 5.02944 7.02944 1 12 1C16.9706 1 21 5.02944 21 10Z" stroke="#808080" stroke-width="1.5"/>
+              <circle cx="12" cy="10" r="3" stroke="#808080" stroke-width="1.5"/>
+            </svg>
+            <span class="ml-2">서울시 마포구</span>
+          </div>
+        </div>
+      </div>
+
+      <!-- 토모토모 -->
+      <div class="flex items-center cursor-pointer" @click="goToDetail(4)">
+        <div class="w-16 h-16 rounded-full bg-gradient-to-br from-orange-400 to-red-500 overflow-hidden mr-6">
+          <div class="w-full h-full flex items-center justify-center">
+            <span class="text-white font-bold text-lg">토</span>
+          </div>
+        </div>
+        <div class="flex-1">
+          <h3 class="text-xl font-semibold text-black mb-1">토모토모</h3>
+          <div class="flex items-center text-gray-500 text-base">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <path d="M21 10C21 17 12 23 12 23S3 17 3 10C3 5.02944 7.02944 1 12 1C16.9706 1 21 5.02944 21 10Z" stroke="#808080" stroke-width="1.5"/>
+              <circle cx="12" cy="10" r="3" stroke="#808080" stroke-width="1.5"/>
+            </svg>
+            <span class="ml-2">부산광역시 해운대구</span>
+          </div>
+        </div>
+      </div>
+
+      <!-- 찰스엔터 -->
+      <div class="flex items-center cursor-pointer" @click="goToDetail(5)">
+        <div class="w-16 h-16 rounded-full bg-gradient-to-br from-purple-400 to-indigo-500 overflow-hidden mr-6">
+          <div class="w-full h-full flex items-center justify-center">
+            <span class="text-white font-bold text-lg">찰</span>
+          </div>
+        </div>
+        <div class="flex-1">
+          <h3 class="text-xl font-semibold text-black mb-1">찰스엔터</h3>
+          <div class="flex items-center text-gray-500 text-base">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <path d="M21 10C21 17 12 23 12 23S3 17 3 10C3 5.02944 7.02944 1 12 1C16.9706 1 21 5.02944 21 10Z" stroke="#808080" stroke-width="1.5"/>
+              <circle cx="12" cy="10" r="3" stroke="#808080" stroke-width="1.5"/>
+            </svg>
+            <span class="ml-2">서울시 강남구</span>
+          </div>
+        </div>
+      </div>
+
+      <!-- 뭐랭하맨 -->
+      <div class="flex items-center cursor-pointer" @click="goToDetail(6)">
+        <div class="w-16 h-16 rounded-full bg-gradient-to-br from-yellow-400 to-orange-500 overflow-hidden mr-6">
+          <div class="w-full h-full flex items-center justify-center">
+            <span class="text-white font-bold text-lg">뭐</span>
+          </div>
+        </div>
+        <div class="flex-1">
+          <h3 class="text-xl font-semibold text-black mb-1">뭐랭하맨</h3>
+          <div class="flex items-center text-gray-500 text-base">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <path d="M21 10C21 17 12 23 12 23S3 17 3 10C3 5.02944 7.02944 1 12 1C16.9706 1 21 5.02944 21 10Z" stroke="#808080" stroke-width="1.5"/>
+              <circle cx="12" cy="10" r="3" stroke="#808080" stroke-width="1.5"/>
+            </svg>
+            <span class="ml-2">서울시 강남구</span>
+          </div>
+        </div>
+      </div>
+
+      <!-- 빠더너스 BDNS -->
+      <div class="flex items-center cursor-pointer" @click="goToDetail(7)">
+        <div class="w-16 h-16 rounded-full bg-gradient-to-br from-teal-400 to-blue-500 overflow-hidden mr-6">
+          <div class="w-full h-full flex items-center justify-center">
+            <span class="text-white font-bold text-lg">빠</span>
+          </div>
+        </div>
+        <div class="flex-1">
+          <h3 class="text-xl font-semibold text-black mb-1">빠더너스 BDNS</h3>
+          <div class="flex items-center text-gray-500 text-base">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <path d="M21 10C21 17 12 23 12 23S3 17 3 10C3 5.02944 7.02944 1 12 1C16.9706 1 21 5.02944 21 10Z" stroke="#808080" stroke-width="1.5"/>
+              <circle cx="12" cy="10" r="3" stroke="#808080" stroke-width="1.5"/>
+            </svg>
+            <span class="ml-2">서울시 강남구</span>
+          </div>
+        </div>
+      </div>
+
+      <!-- 쯔양 -->
+      <div class="flex items-center cursor-pointer" @click="goToDetail(8)">
+        <div class="w-16 h-16 rounded-full bg-gradient-to-br from-rose-400 to-pink-500 overflow-hidden mr-6">
+          <div class="w-full h-full flex items-center justify-center">
+            <span class="text-white font-bold text-lg">쯔</span>
+          </div>
+        </div>
+        <div class="flex-1">
+          <h3 class="text-xl font-semibold text-black mb-1">쯔양</h3>
+          <div class="flex items-center text-gray-500 text-base">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <path d="M21 10C21 17 12 23 12 23S3 17 3 10C3 5.02944 7.02944 1 12 1C16.9706 1 21 5.02944 21 10Z" stroke="#808080" stroke-width="1.5"/>
+              <circle cx="12" cy="10" r="3" stroke="#808080" stroke-width="1.5"/>
+            </svg>
+            <span class="ml-2">서울시 강남구</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, onMounted } from 'vue'
+import { useRouter } from 'vue-router'
+
+const router = useRouter()
+const searchQuery = ref('')
+
+// Sample fan meeting data - 실제로는 API에서 가져올 데이터
+const fanMeetings = ref([
+  {
+    id: 1,
+    title: '2025 여단오 팬미팅 \'내가 제일 예뻐\'',
+    venue: '올림픽공원 체조경기장',
+    date: '2025년 8월 15일 (목) 오후 7:00',
+    price: '36,000',
+    image: null
+  },
+  {
+    id: 2,
+    title: '아이유 팬미팅 \'Through the Night\'',
+    venue: '잠실실내체육관',
+    date: '2025년 9월 20일 (토) 오후 6:00',
+    price: '45,000',
+    image: null
+  }
+])
+
+const filteredFanMeetings = computed(() => {
+  if (!searchQuery.value) {
+    return fanMeetings.value
+  }
+  return fanMeetings.value.filter(fanMeeting => 
+    fanMeeting.title.toLowerCase().includes(searchQuery.value.toLowerCase()) ||
+    fanMeeting.venue.toLowerCase().includes(searchQuery.value.toLowerCase())
+  )
+})
+
+const goBack = () => {
+  router.go(-1)
+}
+
+const goToDetail = (id) => {
+  router.push(`/fan-meeting/${id}`)
+}
+
+const goToSeatSelection = (id) => {
+  router.push(`/seat-select/${id}`)
+}
+
+onMounted(() => {
+  // 팬미팅 데이터 로드
+  // fetchFanMeetings()
+})
+</script>

--- a/src/pages/FanMeetingPaymentPage.vue
+++ b/src/pages/FanMeetingPaymentPage.vue
@@ -1,0 +1,212 @@
+<template>
+  <div class="w-full min-h-screen bg-white">
+    <!-- Header -->
+    <div class="flex items-center justify-between p-4 bg-white border-b border-gray-200">
+      <button @click="goBack" class="p-2">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <path d="M15 18L9 12L15 6" stroke="#000000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+        </svg>
+      </button>
+      <h1 class="text-lg font-semibold text-black">결제하기</h1>
+      <div class="w-6"></div>
+    </div>
+
+    <div class="px-4 pb-24">
+      <!-- Order Summary -->
+      <div class="bg-gray-50 rounded-lg p-4 mb-6 mt-4">
+        <h2 class="text-lg font-bold text-black mb-3">주문 정보</h2>
+        <div class="space-y-2">
+          <div class="flex justify-between">
+            <span class="text-gray-600">팬미팅</span>
+            <span class="text-black font-medium">2025 여단오 팬미팅 '내가 제일 예뻐'</span>
+          </div>
+          <div class="flex justify-between">
+            <span class="text-gray-600">장소</span>
+            <span class="text-black">올림픽공원 체조경기장</span>
+          </div>
+          <div class="flex justify-between">
+            <span class="text-gray-600">일시</span>
+            <span class="text-black">2025년 8월 15일 (목) 오후 7:00</span>
+          </div>
+          <div class="flex justify-between">
+            <span class="text-gray-600">좌석</span>
+            <span class="text-black font-medium">{{ selectedSeat }}</span>
+          </div>
+          <hr class="my-3">
+          <div class="flex justify-between text-lg font-bold">
+            <span class="text-black">총 결제금액</span>
+            <span class="text-brand-accent">{{ totalPrice }}원</span>
+          </div>
+        </div>
+      </div>
+
+      <!-- Payment Method -->
+      <div class="mb-6">
+        <h3 class="text-lg font-bold text-black mb-4">결제 방법</h3>
+        <div class="space-y-3">
+          <label 
+            v-for="method in paymentMethods" 
+            :key="method.id"
+            class="flex items-center p-4 border-2 rounded-lg cursor-pointer transition-colors"
+            :class="{
+              'border-brand-primary bg-brand-primary bg-opacity-10': selectedPaymentMethod === method.id,
+              'border-gray-200': selectedPaymentMethod !== method.id
+            }"
+          >
+            <input 
+              type="radio" 
+              :value="method.id" 
+              v-model="selectedPaymentMethod"
+              class="sr-only"
+            >
+            <div class="flex items-center">
+              <div class="w-6 h-6 mr-3">
+                <svg v-if="method.id === 'kb'" width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                  <rect x="2" y="5" width="20" height="14" rx="2" fill="#FFB800" stroke="#FFB800" stroke-width="2"/>
+                  <text x="12" y="14" text-anchor="middle" fill="white" font-size="8" font-weight="bold">KB</text>
+                </svg>
+                <svg v-else-if="method.id === 'kakao'" width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                  <circle cx="12" cy="12" r="10" fill="#FEE500"/>
+                  <path d="M12 6C8.5 6 6 8.5 6 11.5C6 13.5 7.5 15.5 9.5 16.5L8.5 19.5L11.5 17.5C11.7 17.5 11.8 17.5 12 17.5C15.5 17.5 18 15 18 11.5C18 8.5 15.5 6 12 6Z" fill="#3C1E1E"/>
+                </svg>
+                <svg v-else width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                  <circle cx="12" cy="12" r="10" fill="#03C75A"/>
+                  <path d="M16 10L12 14L8 10" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                </svg>
+              </div>
+              <span class="font-medium text-black">{{ method.name }}</span>
+            </div>
+          </label>
+        </div>
+      </div>
+
+
+
+      <!-- Agreement -->
+      <div class="mb-6">
+        <label class="flex items-start">
+          <input 
+            type="checkbox" 
+            v-model="agreedToTerms"
+            class="mt-1 mr-3 w-4 h-4 text-brand-primary border-gray-300 rounded focus:ring-brand-primary"
+          >
+          <span class="text-sm text-gray-700">
+            <span class="font-medium">결제 진행 동의</span><br>
+            주문 내용을 확인하였으며, 결제에 동의합니다.
+          </span>
+        </label>
+      </div>
+    </div>
+
+    <!-- Bottom Spacer for Navigation -->
+    <div class="h-32"></div>
+
+    <!-- Bottom Button -->
+    <div class="fixed bottom-20 left-0 right-0 p-4 bg-white border-t border-gray-200">
+      <div class="max-w-sm mx-auto px-4">
+        <button 
+          @click="processPayment"
+          :disabled="!canProceed"
+          :class="{
+            'bg-brand-primary text-black': canProceed,
+            'bg-gray-300 text-gray-500': !canProceed
+          }"
+          class="w-full py-4 rounded-xl font-bold text-lg transition-colors"
+        >
+          {{ totalPrice }}원 결제하기
+        </button>
+      </div>
+    </div>
+
+    <!-- Loading Modal -->
+    <div v-if="isProcessing" class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+      <div class="bg-white rounded-lg p-6 text-center">
+        <div class="animate-spin rounded-full h-12 w-12 border-b-2 border-brand-primary mx-auto mb-4"></div>
+        <p class="text-gray-700">결제 처리 중...</p>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, onMounted } from 'vue'
+import { useRouter, useRoute } from 'vue-router'
+
+const router = useRouter()
+const route = useRoute()
+
+const selectedSeat = ref('')
+const totalPrice = ref('36,000')
+const selectedPaymentMethod = ref('kb')
+const agreedToTerms = ref(false)
+const isProcessing = ref(false)
+
+const paymentMethods = [
+  { id: 'kb', name: 'KB페이' },
+  { id: 'kakao', name: '카카오페이' },
+  { id: 'naver', name: '네이버페이' }
+]
+
+const cardInfo = ref({
+  number: '',
+  expiry: '',
+  cvc: '',
+  name: ''
+})
+
+const canProceed = computed(() => {
+  return agreedToTerms.value && selectedPaymentMethod.value
+})
+
+const formatCardNumber = () => {
+  let value = cardInfo.value.number.replace(/\D/g, '')
+  value = value.replace(/(\d{4})(?=\d)/g, '$1-')
+  cardInfo.value.number = value
+}
+
+const formatExpiry = () => {
+  let value = cardInfo.value.expiry.replace(/\D/g, '')
+  if (value.length >= 2) {
+    value = value.substring(0, 2) + '/' + value.substring(2, 4)
+  }
+  cardInfo.value.expiry = value
+}
+
+const goBack = () => {
+  router.go(-1)
+}
+
+const processPayment = async () => {
+  if (!canProceed.value) return
+  
+  isProcessing.value = true
+  
+  try {
+    // 결제 처리 시뮬레이션
+    await new Promise(resolve => setTimeout(resolve, 2000))
+    
+    // 결제 완료 후 성공 페이지로 이동
+    router.push({
+      path: '/payment-success',
+      query: {
+        fanMeetingId: route.params.id,
+        seat: selectedSeat.value,
+        amount: totalPrice.value.replace(',', '')
+      }
+    })
+  } catch (error) {
+    alert('결제 처리 중 오류가 발생했습니다.')
+  } finally {
+    isProcessing.value = false
+  }
+}
+
+onMounted(() => {
+  // 쿼리 파라미터에서 좌석 정보 가져오기
+  selectedSeat.value = route.query.seat || 'F9'
+  if (route.query.price) {
+    const price = parseInt(route.query.price)
+    totalPrice.value = price.toLocaleString()
+  }
+})
+</script>

--- a/src/pages/FanMeetingPaymentPage.vue
+++ b/src/pages/FanMeetingPaymentPage.vue
@@ -99,10 +99,10 @@
     </div>
 
     <!-- Bottom Spacer for Navigation -->
-    <div class="h-32"></div>
+    <div class="h-20"></div>
 
     <!-- Bottom Button -->
-    <div class="fixed bottom-20 left-0 right-0 p-4 bg-white border-t border-gray-200">
+    <div class="fixed bottom-0 left-0 right-0 p-4 bg-white border-t border-gray-200">
       <div class="max-w-sm mx-auto px-4">
         <button 
           @click="processPayment"

--- a/src/pages/PaymentSuccessPage.vue
+++ b/src/pages/PaymentSuccessPage.vue
@@ -1,0 +1,97 @@
+<template>
+  <div class="w-full min-h-screen bg-white flex flex-col">
+    <!-- Header -->
+    <div class="flex items-center justify-between p-4 bg-white border-b border-gray-200">
+      <div class="w-6"></div>
+      <h1 class="text-lg font-semibold text-black">결제 완료</h1>
+      <button @click="goHome" class="p-2">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <path d="M6 18L18 6M6 6l12 12" stroke="#000000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+        </svg>
+      </button>
+    </div>
+
+    <!-- Success Content -->
+    <div class="flex-1 flex flex-col items-center justify-center px-4">
+      <!-- Success Icon -->
+      <div class="w-20 h-20 bg-green-100 rounded-full flex items-center justify-center mb-6">
+        <svg width="40" height="40" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <path d="M9 12L11 14L15 10M21 12C21 16.9706 16.9706 21 12 21C7.02944 21 3 16.9706 3 12C3 7.02944 7.02944 3 12 3C16.9706 3 21 7.02944 21 12Z" stroke="#10B981" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+        </svg>
+      </div>
+
+      <h2 class="text-2xl font-bold text-black mb-2">결제가 완료되었습니다!</h2>
+      <p class="text-gray-600 text-center mb-8">팬미팅 예매가 성공적으로 완료되었습니다.</p>
+
+      <!-- Order Details -->
+      <div class="w-full max-w-sm bg-gray-50 rounded-lg p-4 mb-8">
+        <h3 class="font-bold text-black mb-3">예매 정보</h3>
+        <div class="space-y-2 text-sm">
+          <div class="flex justify-between">
+            <span class="text-gray-600">팬미팅</span>
+            <span class="text-black">2025 여단오 팬미팅</span>
+          </div>
+          <div class="flex justify-between">
+            <span class="text-gray-600">좌석</span>
+            <span class="text-black font-medium">{{ selectedSeat }}</span>
+          </div>
+          <div class="flex justify-between">
+            <span class="text-gray-600">결제금액</span>
+            <span class="text-brand-accent font-bold">{{ amount }}원</span>
+          </div>
+        </div>
+      </div>
+
+      <!-- Action Buttons -->
+      <div class="w-full max-w-sm space-y-3">
+        <button 
+          @click="viewTicket"
+          class="w-full bg-brand-primary text-black py-4 rounded-xl font-bold text-lg transition-colors hover:bg-brand-accent"
+        >
+          티켓 확인하기
+        </button>
+        <button 
+          @click="goHome"
+          class="w-full bg-gray-100 text-gray-700 py-4 rounded-xl font-medium text-lg transition-colors hover:bg-gray-200"
+        >
+          홈으로 돌아가기
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue'
+import { useRouter, useRoute } from 'vue-router'
+
+const router = useRouter()
+const route = useRoute()
+
+const selectedSeat = ref('')
+const amount = ref('')
+const fanMeetingId = ref('')
+
+const goHome = () => {
+  router.push('/')
+}
+
+const viewTicket = () => {
+  // 티켓 상세 페이지로 이동
+  router.push({
+    path: '/ticket',
+    query: {
+      fanMeetingId: fanMeetingId.value,
+      seat: selectedSeat.value,
+      amount: amount.value
+    }
+  })
+}
+
+onMounted(() => {
+  // 쿼리 파라미터에서 정보 가져오기
+  selectedSeat.value = route.query.seat || ''
+  amount.value = route.query.amount ? parseInt(route.query.amount).toLocaleString() : ''
+  fanMeetingId.value = route.query.fanMeetingId || ''
+})
+</script>

--- a/src/pages/SeatSelectPage.vue
+++ b/src/pages/SeatSelectPage.vue
@@ -15,8 +15,8 @@
     <div class="px-4 py-3 bg-gray-50">
       <div class="flex items-center mb-1">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-          <path d="M21 10C21 17 12 23 12 23S3 17 3 10C3 5.02944 7.02944 1 12 1C16.9706 1 21 5.02944 21 10Z" stroke="#6B7280" stroke-width="2"/>
-          <circle cx="12" cy="10" r="3" stroke="#6B7280" stroke-width="2"/>
+          <path d="M21 10C21 17 12 23 12 23S3 17 3 10C3 5.02944 7.02944 1 12 1C16.9706 1 21 5.02944 21 10Z" stroke="#808080" stroke-width="2"/>
+          <circle cx="12" cy="10" r="3" stroke="#808080" stroke-width="2"/>
         </svg>
         <span class="ml-1 text-sm text-gray-600">{{ currentFanMeeting.venue }}</span>
       </div>
@@ -88,7 +88,7 @@
     </div>
 
     <!-- Bottom Button -->
-    <div class="fixed bottom-20 left-0 right-0 p-4 bg-white border-t border-gray-200" style="padding-bottom: calc(1rem + env(safe-area-inset-bottom, 0px));">
+    <div class="fixed bottom-0 left-0 right-0 p-4 bg-white border-t border-gray-200" style="padding-bottom: calc(1rem + env(safe-area-inset-bottom, 0px));">
       <div class="max-w-sm mx-auto px-4">
         <button 
           @click="proceedToPayment"
@@ -105,7 +105,7 @@
     </div>
 
     <!-- Bottom Spacer for Navigation -->
-    <div class="h-32"></div>
+    <div class="h-20"></div>
   </div>
 </template>
 

--- a/src/pages/SeatSelectPage.vue
+++ b/src/pages/SeatSelectPage.vue
@@ -1,0 +1,241 @@
+<template>
+  <div class="w-full min-h-screen bg-white">
+    <!-- Header -->
+    <div class="flex items-center justify-between p-4 bg-white border-b border-gray-200">
+      <button @click="goBack" class="p-2">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <path d="M15 18L9 12L15 6" stroke="#000000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+        </svg>
+      </button>
+      <h1 class="text-lg font-semibold text-black">좌석 선택</h1>
+      <div class="w-6"></div>
+    </div>
+
+    <!-- Fan Meeting Info -->
+    <div class="px-4 py-3 bg-gray-50">
+      <div class="flex items-center mb-1">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <path d="M21 10C21 17 12 23 12 23S3 17 3 10C3 5.02944 7.02944 1 12 1C16.9706 1 21 5.02944 21 10Z" stroke="#6B7280" stroke-width="2"/>
+          <circle cx="12" cy="10" r="3" stroke="#6B7280" stroke-width="2"/>
+        </svg>
+        <span class="ml-1 text-sm text-gray-600">{{ currentFanMeeting.venue }}</span>
+      </div>
+      <h2 class="text-lg font-bold text-black mb-1">{{ currentFanMeeting.title }}</h2>
+      <p class="text-sm text-gray-600">{{ currentFanMeeting.date }}</p>
+    </div>
+
+    <!-- Stage -->
+    <div class="px-4 py-6">
+      <div class="bg-gray-800 rounded-xl py-4 mb-8">
+        <p class="text-center text-white font-bold text-lg">STAGE</p>
+      </div>
+
+      <!-- Seat Map -->
+      <div class="space-y-4">
+        <!-- Row Labels -->
+        <div class="flex justify-center mb-4">
+          <div class="text-xs text-gray-600 space-y-2 mr-4">
+            <div v-for="row in seatRows" :key="row" class="h-8 flex items-center">
+              {{ row }}
+            </div>
+          </div>
+          
+          <!-- Seats Grid -->
+          <div class="space-y-2">
+            <div v-for="(row, rowIndex) in seatMap" :key="rowIndex" class="flex space-x-1">
+              <button
+                v-for="(seat, seatIndex) in row"
+                :key="seatIndex"
+                @click="selectSeat(rowIndex, seatIndex)"
+                :disabled="seat.status === 'occupied'"
+                :class="getSeatClass(seat)"
+                class="w-8 h-8 rounded text-xs font-medium transition-colors"
+              >
+                {{ seat.number }}
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Seat Legend -->
+      <div class="flex justify-center space-x-6 mb-6">
+        <div class="flex items-center">
+          <div class="w-4 h-4 bg-white border-2 border-gray-300 rounded mr-2"></div>
+          <span class="text-xs text-gray-600">선택 가능</span>
+        </div>
+        <div class="flex items-center">
+          <div class="w-4 h-4 bg-brand-primary rounded mr-2"></div>
+          <span class="text-xs text-gray-600">선택됨</span>
+        </div>
+        <div class="flex items-center">
+          <div class="w-4 h-4 bg-gray-400 rounded mr-2"></div>
+          <span class="text-xs text-gray-600">선택 불가</span>
+        </div>
+      </div>
+    </div>
+
+    <!-- Selected Seat Info -->
+    <div v-if="selectedSeat" class="px-4 py-3 bg-gray-50 border-t border-gray-200">
+      <div class="flex justify-between items-center mb-2">
+        <span class="text-sm text-gray-600">선택</span>
+        <span class="text-sm font-medium text-black">{{ selectedSeat.row }}{{ selectedSeat.number }}</span>
+      </div>
+      <div class="flex justify-between items-center">
+        <span class="text-sm text-gray-600">가격</span>
+        <span class="text-lg font-bold text-brand-accent">36,000원</span>
+      </div>
+    </div>
+
+    <!-- Bottom Button -->
+    <div class="fixed bottom-20 left-0 right-0 p-4 bg-white border-t border-gray-200" style="padding-bottom: calc(1rem + env(safe-area-inset-bottom, 0px));">
+      <div class="max-w-sm mx-auto px-4">
+        <button 
+          @click="proceedToPayment"
+          :disabled="!selectedSeat"
+          :class="{
+            'bg-brand-primary text-black': selectedSeat,
+            'bg-gray-300 text-gray-500': !selectedSeat
+          }"
+          class="w-full py-4 rounded-xl font-bold text-lg transition-colors"
+        >
+          예매하기
+        </button>
+      </div>
+    </div>
+
+    <!-- Bottom Spacer for Navigation -->
+    <div class="h-32"></div>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed } from 'vue'
+import { useRouter, useRoute } from 'vue-router'
+
+const router = useRouter()
+const route = useRoute()
+
+const selectedSeat = ref(null)
+const seatRows = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O']
+
+// 팬미팅 데이터
+const fanMeetingData = {
+  1: {
+    name: '태요미네',
+    title: '2025 태요미네 팬미팅 \'내가 제일 예뻐\'',
+    date: '2025년 8월 15일 (목) 오후 7:00',
+    venue: '올림픽공원 체조경기장'
+  },
+  2: {
+    name: '여단오',
+    title: '2025 여단오 팬미팅 \'내가 제일 예뻐\'',
+    date: '2025년 8월 20일 (화) 오후 7:00',
+    venue: '올림픽공원 체조경기장'
+  },
+  3: {
+    name: '김민지',
+    title: '2025 김민지 팬미팅 \'내가 제일 예뻐\'',
+    date: '2025년 8월 25일 (일) 오후 7:00',
+    venue: '올림픽공원 체조경기장'
+  },
+  4: {
+    name: '이서연',
+    title: '2025 이서연 팬미팅 \'내가 제일 예뻐\'',
+    date: '2025년 9월 1일 (일) 오후 7:00',
+    venue: '올림픽공원 체조경기장'
+  },
+  5: {
+    name: '박지우',
+    title: '2025 박지우 팬미팅 \'내가 제일 예뻐\'',
+    date: '2025년 9월 5일 (목) 오후 7:00',
+    venue: '올림픽공원 체조경기장'
+  },
+  6: {
+    name: '최유나',
+    title: '2025 최유나 팬미팅 \'내가 제일 예뻐\'',
+    date: '2025년 9월 10일 (화) 오후 7:00',
+    venue: '올림픽공원 체조경기장'
+  },
+  7: {
+    name: '정하린',
+    title: '2025 정하린 팬미팅 \'내가 제일 예뻐\'',
+    date: '2025년 9월 15일 (일) 오후 7:00',
+    venue: '올림픽공원 체조경기장'
+  },
+  8: {
+    name: '송예린',
+    title: '2025 송예린 팬미팅 \'내가 제일 예뻐\'',
+    date: '2025년 9월 20일 (금) 오후 7:00',
+    venue: '올림픽공원 체조경기장'
+  }
+}
+
+// 현재 팬미팅 정보
+const currentFanMeeting = computed(() => {
+  return fanMeetingData[route.params.id] || fanMeetingData[1]
+})
+
+// 좌석 맵 생성 (Figma 디자인 기반)
+const seatMap = ref([
+  // A-O 행, 각 행당 11개 좌석
+  ...Array.from({ length: 15 }, (_, rowIndex) => 
+    Array.from({ length: 11 }, (_, seatIndex) => ({
+      number: seatIndex + 1,
+      row: seatRows[rowIndex],
+      status: Math.random() > 0.7 ? 'occupied' : 'available', // 랜덤하게 일부 좌석 점유
+      selected: false
+    }))
+  )
+])
+
+const selectSeat = (rowIndex, seatIndex) => {
+  const seat = seatMap.value[rowIndex][seatIndex]
+  
+  if (seat.status === 'occupied') return
+  
+  // 기존 선택 해제
+  if (selectedSeat.value) {
+    const prevSeat = seatMap.value.find(row => 
+      row.find(s => s.selected)
+    )?.find(s => s.selected)
+    if (prevSeat) prevSeat.selected = false
+  }
+  
+  // 새 좌석 선택
+  seat.selected = true
+  selectedSeat.value = {
+    row: seat.row,
+    number: seat.number,
+    rowIndex,
+    seatIndex
+  }
+}
+
+const getSeatClass = (seat) => {
+  if (seat.status === 'occupied') {
+    return 'bg-gray-400 text-white cursor-not-allowed'
+  }
+  if (seat.selected) {
+    return 'bg-brand-primary text-black border-2 border-brand-accent'
+  }
+  return 'bg-white border-2 border-gray-300 text-gray-700 hover:border-brand-primary'
+}
+
+const goBack = () => {
+  router.go(-1)
+}
+
+const proceedToPayment = () => {
+  if (!selectedSeat.value) return
+  
+  // 선택된 좌석 정보를 쿼리 파라미터로 전달
+  router.push({
+    path: `/payment/${route.params.id}`,
+    query: {
+      seat: `${selectedSeat.value.row}${selectedSeat.value.number}`,
+      price: '36000'
+    }
+  })
+}
+</script>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -6,6 +6,9 @@ import FanCardPage from '@/pages/FanCardPage.vue'
 import FanMeetingPage from '@/pages/FanMeetingPage.vue'
 import HomePage from '@/pages/HomePage.vue'
 import FanMeetingDetailPage from '@/pages/FanMeetingDetailPage.vue'
+import SeatSelectPage from '@/pages/SeatSelectPage.vue'
+import FanMeetingPaymentPage from '@/pages/FanMeetingPaymentPage.vue'
+import PaymentSuccessPage from '@/pages/PaymentSuccessPage.vue'
 
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
@@ -22,14 +25,29 @@ const router = createRouter({
       component: DesignGuidePage, // 👈 여기 추가
     },
     {
-      path: '/reservation/:id',
+      path: '/fan-meeting/:id',
       name: 'FanMeetingDetail',
       component: FanMeetingDetailPage
+    },
+    {
+      path: '/seat-select/:id',
+      name: 'SeatSelect',
+      component: SeatSelectPage
+    },
+    {
+      path: '/payment/:id',
+      name: 'Payment',
+      component: FanMeetingPaymentPage
+    },
+    {
+      path: '/payment-success',
+      name: 'PaymentSuccess',
+      component: PaymentSuccessPage
     },
     // 아래는 테스트용이라 추후 삭제 예정
     {
       path: '/reservation/detail',
-      name: 'FanMeetingDetail',
+      name: 'FanMeetingDetailOld',
       component: FanMeetingDetailPage
     }
     


### PR DESCRIPTION
## 🔖 PR 유형
- [x] ✨ 기능 추가
- [ ] 🐛 버그 수정
- [x] ♻️ 리팩토링
- [ ] 🧪 테스트 코드 추가
- [ ] 📄 문서 수정
- [ ] 기타

## 📌 개요
 팬미팅 예약 시스템의 전체 플로우를 구현했습니다.

🔧 작업 내용
- 팬미팅 리스트 페이지 (FanMeetingPage.vue) 구현:
  - 인플루언서 목록 표시 (태요미네, 여단오, 침착맨 등 8개)
  - 검색 기능 UI 구현
  - 각 인플루언서별 상세 페이지 연결

- 팬미팅 상세 페이지 (FanMeetingDetailPage.vue) 구현:
  - 팬미팅 정보 상세 표시
  - 예매하기 버튼으로 좌석 선택 페이지 연결

- 좌석 선택 페이지 (SeatSelectPage.vue) 구현:
  - 스테이지 중심의 좌석 배치도
  - 좌석 상태별 색상 구분 (선택가능/선택됨/선택불가)
  - 선택된 좌석 정보 실시간 표시
  - 예매하기 버튼으로 결제 페이지 연결

- 결제 페이지 (FanMeetingPaymentPage.vue) 구현:
  - 주문 정보 요약 (팬미팅, 장소, 일시, 좌석, 가격)
  - 결제 방법 선택 (KB페이, 카카오페이, 네이버페이)
  - 약관 동의 체크박스 (임의로 추가)
  - 결제 처리 로딩 상태 및 완료 페이지 연결

- 예약 관련 페이지들을 src/pages/reservation/ 폴더로 구조화

## ♻️ 리팩토링

  - 디자인 시스템 가이드라인 적용:
    - 하드코딩된 컬러를 커스텀 Tailwind 클래스로 변경
    - 인라인 스타일 제거 및 표준 클래스 적용
    - 컨테이너 사이즈 가이드라인 준수
    - 코드 일관성 및 유지보수성 향상

## ✅ 체크리스트
예약 페이지
<img width="428" height="926" alt="image" src="https://github.com/user-attachments/assets/65ce1dfe-978f-499e-85fd-3928119c557f" />

예약 상세 페이지
<img width="426" height="928" alt="image" src="https://github.com/user-attachments/assets/d7a9ea13-5055-4aa1-9f16-f6bfb320219e" />

좌석 선택 페이지(선택 전)
<img width="428" height="929" alt="image" src="https://github.com/user-attachments/assets/fd245fd1-f5e7-4b62-84fa-8a3ee6d0a642" />

좌석 선택 패에지(선택 후)
<img width="427" height="928" alt="image" src="https://github.com/user-attachments/assets/30625ca2-b699-4a8c-94cb-efa6feb5058a" />

결제 페이지(동의 전)
<img width="428" height="929" alt="image" src="https://github.com/user-attachments/assets/f9acf4e0-293a-4808-b1ea-aca60e89f2f1" />

결제 페이지(동의 후)
<img width="427" height="929" alt="image" src="https://github.com/user-attachments/assets/3207f4ee-ed91-44d0-9ce0-92877d721c52" />


## 📝 기타 참고 사항
  - 현재는 더미 데이터로 구현되어 있으며, 추후 백엔드 API 연동 예정
  - 실제 결제 기능은 임시 시뮬레이션으로 구현 (2초 딜레이)
  - 좌석 상태 관리 로직 추후 서버 연동 시 개선 예정
  - 결제 완료 페이지 올라오는 대로 연결 및 티켓 보기 버튼 추가 예정
 
## 📎 관련 이슈
Close #18 