### PR TITLE
[refactor] Tailwind 디자인 시스템 리팩토링: 버튼/뱃지 컴포넌트화 및 설정 최적화

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,13 +1,11 @@
 <script setup>
 import { RouterLink, RouterView } from 'vue-router'
 
-import AppNav from './components/layout/AppNav.vue';
 </script>
 
 <template>
    <div class="w-full max-w-[393px] md:max-w-[430px] mx-auto">
     <router-view />
-    <app-nav></app-nav>
   </div>
 </template> 
 

--- a/src/components/layout/AppHeader.vue
+++ b/src/components/layout/AppHeader.vue
@@ -1,36 +1,3 @@
-<template>
-  <header
-    class="w-full max-w-[393px] md:max-w-[430px] h-[48px] flex items-center px-[20px] bg-base shadow mx-auto"
-  >
-    <div v-if="type !== 'logo'" class="flex items-center gap-[8px]">
-      <img src="@/assets/header/BackIcon.svg" alt="Back" class="cursor-pointer" />
-    </div>
-
-    <div v-else class="flex items-center">
-      <img src="@/assets/header/LogoName.svg" alt="Logo" class="h-[24px]" />
-    </div>
-
-    <span
-      v-if="type === 'back-title' || type === 'back-title-icons'"
-      class="absolute left-1/2 transform -translate-x-1/2 text-[16px] font-semibold text-text-base"
-    >
-      {{ title }}
-    </span>
-
-    <div
-      v-if="type === 'back-icons' || type === 'back-title-icons'"
-      class="flex items-center gap-[12px] ml-auto"
-    >
-      <img src="@/assets/header/CartIcon.svg" alt="Cart" class="cursor-pointer hover:opacity-80" />
-      <img
-        src="@/assets/header/Magnifier.svg"
-        alt="Search"
-        class="cursor-pointer hover:opacity-80"
-      />
-    </div>
-  </header>
-</template>
-
 <script setup>
 defineProps({
   type: {
@@ -43,3 +10,36 @@ defineProps({
   },
 })
 </script>
+
+<template>
+  <header
+    class="w-full max-w-xs md:max-w-sm h-12 flex items-center bg-base mx-auto"
+  >
+    <div v-if="type !== 'logo'" class="flex items-center gap-2">
+      <img src="@/assets/header/BackIcon.svg" alt="Back" class="cursor-pointer" />
+    </div>
+
+    <div v-else class="flex items-center">
+      <img src="@/assets/header/LogoName.svg" alt="Logo" class="h-6" />
+    </div>
+
+    <span
+      v-if="type === 'back-title' || type === 'back-title-icons'"
+      class="absolute left-1/2 -translate-x-1/2 text-base font-semibold text-text-base"
+    >
+      {{ title }}
+    </span>
+
+    <div
+      v-if="type === 'back-icons' || type === 'back-title-icons'"
+      class="flex items-center gap-3 ml-auto"
+    >
+      <img src="@/assets/header/CartIcon.svg" alt="Cart" class="cursor-pointer hover:opacity-80" />
+      <img
+        src="@/assets/header/Magnifier.svg"
+        alt="Search"
+        class="cursor-pointer hover:opacity-80"
+      />
+    </div>
+  </header>
+</template>

--- a/src/components/layout/AppNav.vue
+++ b/src/components/layout/AppNav.vue
@@ -23,32 +23,30 @@ const navItems = [
 ]
 
 const isActive = (path) => {
-  if (path === '/') {
-    return route.path === '/'
-  }
-  return route.path.startsWith(path)
+  return path === '/' ? route.path === '/' : route.path.startsWith(path)
 }
 </script>
+
 <template>
   <nav
-    class="fixed bottom-0 left-1/2 -translate-x-1/2 w-full max-w-[430px] h-[76px] bg-white border-t border-l border-r border-[#EFEFEF] rounded-t-[16px] flex items-center justify-center z-50"
+    class="fixed bottom-0 left-0 w-full h-20 bg-white border-t border-[#efefef] rounded-t-2xl flex items-center justify-center z-50"
   >
-    <div class="flex justify-between w-full px-[20px]">
+    <div class="flex justify-between items-center w-full max-w-sm mx-auto px-5">
       <RouterLink
         v-for="item in navItems"
         :key="item.path"
         :to="item.path"
-        class="flex flex-col items-center gap-[8px] w-[56px]"
+        class="flex flex-col items-center gap-2 w-14"
         :aria-label="item.name"
       >
         <img
           :src="isActive(item.path) ? item.iconActive : item.icon"
-          class="w-[24px] h-[24px]"
+          class="w-6 h-6"
           :alt="item.name"
         />
         <span
           :class="[
-            'block text-[12px] leading-none text-center whitespace-nowrap transition-colors duration-200',
+            'block text-xs leading-none text-center whitespace-nowrap transition-colors duration-200',
             isActive(item.path) ? 'text-black' : 'text-[#A7A7A7]',
           ]"
         >

--- a/src/components/layout/LayoutWrapper.vue
+++ b/src/components/layout/LayoutWrapper.vue
@@ -1,0 +1,5 @@
+<template>
+    <div class="w-full max-w-screen-sm mx-auto px-5">
+      <slot />
+    </div>
+  </template>

--- a/src/pages/DesignGuidePage.vue
+++ b/src/pages/DesignGuidePage.vue
@@ -1,47 +1,32 @@
 <template>
   <div
-    class="min-h-screen bg-subtle-bg px-4 space-y-6 font-sans mx-auto w-full max-w-[393px] md:max-w-[430px]"
+    class="min-h-screen bg-subtle-bg px-4 space-y-6 font-sans mx-auto w-full max-w-xs md:max-w-sm"
   >
     <h1 class="text-[1.5rem] font-bold mb-4">🎨 Design System Guide</h1>
-    <p class="text-subtle-text text-[0.875rem] mb-6 leading-relaxed">
+    <p class="text-subtle-text text-sm mb-6 leading-relaxed">
       ✅ 이 프로젝트의 UI 요소는 <strong>Tailwind 커스텀 클래스</strong>로 미리 정의되어 있어,
       <code>.btn-primary</code>, <code>.badge-vip</code> 와 같이
       <strong>클래스를 붙여 쓰면 동일한 디자인</strong>을 바로 적용할 수 있습니다.
     </p>
 
     <section>
-      <h2 class="text-[1.25rem] font-semibold mb-3">🎨 Color Palette</h2>
-      <div class="grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4">
+      <h2 class="text-xl font-semibold mb-3">🎨 Color Palette</h2>
+      <div class="grid grid-cols-2 gap-3 sm:grid-cols-4 md:grid-cols-3">
         <div
           v-for="(color, index) in colorPalette"
           :key="index"
           :class="`p-3 rounded text-center ${color.bg} ${color.text} ${color.border || ''}`"
         >
-          <p class="font-bold text-[0.875rem]">{{ color.name }}</p>
-          <p>{{ color.hex }}</p>
-          <p class="text-[0.75rem] mt-1">{{ color.description }}</p>
+          <p class="font-bold text-sm">{{ color.name }}</p>
+          <p class="text-xs">{{ color.hex }}</p>
+          <p class="text-xs mt-1">{{ color.description }}</p>
         </div>
       </div>
     </section>
 
     <section class="mt-8">
-      <h2 class="text-[1.25rem] font-semibold mb-3">🖱️ Buttons</h2>
-      <p class="text-subtle-text text-[0.75rem] mb-3">
-        버튼은 공통 클래스(<code>.btn</code>)로 정의되며 일관된 높이(48px), 둥근 모서리(12px)를
-        갖습니다.
-      </p>
-      <div class="space-y-3">
-        <button class="btn btn-primary w-full">Primary Button</button>
-        <button class="btn btn-cart w-full">Cart Button</button>
-        <button class="btn btn-buy w-full">Buy Now Button</button>
-        <button class="btn btn-cancel w-full">Cancel Button</button>
-        <button class="btn btn-confirm w-full">Confirm Button</button>
-      </div>
-    </section>
-
-    <section class="mt-8">
-      <h2 class="text-[1.25rem] font-semibold mb-3">🏷️ Badges</h2>
-      <p class="text-subtle-text text-[0.75rem] mb-3">
+      <h2 class="text-xl font-semibold mb-3">🏷️ Badges</h2>
+      <p class="text-subtle-text text-xs mb-3">
         뱃지는 상태/등급을 표시하며, 공통 사이즈(80x24px), 볼드 텍스트를 사용합니다.
       </p>
       <div class="flex flex-wrap gap-2">
@@ -53,7 +38,7 @@
     </section>
 
     <section class="mt-8">
-      <h2 class="text-[1.25rem] font-semibold mb-3">☂️ Headers</h2>
+      <h2 class="text-xl font-semibold mb-3">☂️ Headers</h2>
       <div class="space-y-2">
         <AppHeader type="logo" />
         <AppHeader type="back" />
@@ -61,55 +46,56 @@
         <AppHeader type="back-icons" />
       </div>
     </section>
-  </div>
-  <section class="p-4 space-y-8 pb-[112px]">
-    <h2 class="text-xl font-bold">🎨 BaseButton 예시 모음</h2>
 
-    <div class="space-y-4">
-      <h3 class="font-semibold">📌 Large Buttons (353x48)</h3>
-      <BaseButton variant="primary" size="lg">기본 버튼</BaseButton>
-      <BaseButton variant="primary" size="lg">
-        <img src="@/assets/button/shopping-bag.svg" alt="장바구니" class="w-[20px] h-[20px]" />
-        장바구니 담기
-      </BaseButton>
+    <section class="space-y-8 pb-28">
+      <h2 class="text-xl font-bold">🎨 BaseButton 예시 모음</h2>
 
-      <BaseButton variant="primary" size="lg">
-        <span class="font-extrabold">12,000원</span>
-        <span class="font-semibold">결제하기</span>
-      </BaseButton>
-    </div>
-
-    <div class="space-y-4">
-      <h3 class="font-semibold">📌 Medium Buttons (169x48)</h3>
-      <div class="flex gap-4">
-        <BaseButton variant="cart" size="md">
-          <img src="@/assets/button/shopping-bag.svg" alt="장바구니" class="w-[20px] h-[20px]" />
+      <div class="space-y-4">
+        <h3 class="font-semibold">📌 Large Buttons (353x48)</h3>
+        <BaseButton variant="primary" size="lg">기본 버튼</BaseButton>
+        <BaseButton variant="primary" size="lg">
+          <img src="@/assets/button/shopping-bag.svg" alt="장바구니" class="w-5 h-5" />
           장바구니 담기
         </BaseButton>
 
-        <BaseButton variant="buy" size="md">바로 구매하기</BaseButton>
+        <BaseButton variant="primary" size="lg">
+          <span class="font-extrabold">12,000원</span>
+          <span class="font-semibold">결제하기</span>
+        </BaseButton>
       </div>
-    </div>
 
-    <div class="space-y-4">
-      <h3 class="font-semibold">📌 Small Buttons (140x48)</h3>
-      <div class="flex gap-4">
-        <BaseButton variant="cancel" size="sm">취소</BaseButton>
-        <BaseButton variant="confirm" size="sm">수정 완료</BaseButton>
+      <div class="space-y-4">
+        <h3 class="font-semibold">📌 Medium Buttons (169x48)</h3>
+        <div class="flex gap-4">
+          <BaseButton variant="cart" size="md">
+            <img src="@/assets/button/shopping-bag.svg" alt="장바구니" class="w-5 h-5" />
+            장바구니 담기
+          </BaseButton>
+
+          <BaseButton variant="buy" size="md">바로 구매하기</BaseButton>
+        </div>
       </div>
-    </div>
-  </section>
 
-  <section class="pb-[112px]">
-    <h2 class="text-[1.25rem] font-semibold mb-3">🔍 Search Bar</h2>
-    <p class="text-subtle-text text-[0.75rem] mb-3">
-      검색창은 입력 상태에 따라 동적으로 너비와 아이콘이 바뀌며, placeholder는 "검색어를
-      입력해주세요."입니다.
-    </p>
-    <div class="bg-white rounded-lg p-4 border border-subtle-border">
-      <SearchBar />
-    </div>
-  </section>
+      <div class="space-y-4">
+        <h3 class="font-semibold">📌 Small Buttons (140x48)</h3>
+        <div class="flex gap-4">
+          <BaseButton variant="cancel" size="sm">취소</BaseButton>
+          <BaseButton variant="confirm" size="sm">수정 완료</BaseButton>
+        </div>
+      </div>
+    </section>
+
+    <section class="pb-28">
+      <h2 class="text-xl font-semibold mb-3">🔍 Search Bar</h2>
+      <p class="text-subtle-text text-xs mb-3">
+        검색창은 입력 상태에 따라 동적으로 너비와 아이콘이 바뀌며, placeholder는 "검색어를
+        입력해주세요."입니다.
+      </p>
+      <div class="bg-base-bg rounded-lg p-4 border border-subtle-border">
+        <SearchBar />
+      </div>
+    </section>
+  </div>
 </template>
 
 <script setup>
@@ -170,8 +156,36 @@ const colorPalette = [
     description: '✔ 서브 텍스트 (비활성화 상태)',
   },
   {
+    name: 'text-base',
+    hex: '#000000',
+    bg: 'bg-base-bg',
+    text: 'text-text-base',
+    description: '✔ 기본 본문 텍스트',
+  },
+  {
+    name: 'text-inverse',
+    hex: '#FFFFFF',
+    bg: 'bg-text-base',
+    text: 'text-text-inverse',
+    description: '✔ 반전 텍스트 (다크 배경용)',
+  },
+  {
+    name: 'text-emphasis',
+    hex: '#F50000',
+    bg: 'bg-text-emphasis',
+    text: 'text-text-inverse',
+    description: '✔ 강조 텍스트',
+  },
+  {
+    name: 'nav-stroke',
+    hex: '#EFEFEF',
+    bg: 'bg-nav-stroke',
+    text: 'text-text-base',
+    description: '✔ 네비게이션 구분선',
+  },
+  {
     name: 'nav-active',
-    hex: '#A8A8A8',
+    hex: '#3A3A3A',
     bg: 'bg-nav-active',
     text: 'text-text-inverse',
     description: '✔ 활성화 네비게이션',
@@ -182,35 +196,6 @@ const colorPalette = [
     bg: 'bg-nav-deactivated',
     text: 'text-text-inverse',
     description: '✔ 비활성화 네비게이션',
-  },
-  {
-    name: 'nav-stroke',
-    hex: '#EFEFEF',
-    bg: 'bg-nav-stroke',
-    text: 'text-text-base',
-    description: '✔ 네비게이션 구분선',
-  },
-  {
-    name: 'text-base',
-    hex: '#000000',
-    bg: 'bg-base-bg',
-    text: 'text-text-base',
-    border: 'border border-base-border',
-    description: '✔ 기본 본문 텍스트',
-  },
-  {
-    name: 'text-emphasis',
-    hex: '#F50000',
-    bg: 'bg-text-emphasis',
-    text: 'text-text-inverse',
-    description: '✔ 강조 텍스트',
-  },
-  {
-    name: 'text-inverse',
-    hex: '#FFFFFF',
-    bg: 'bg-text-base',
-    text: 'text-text-inverse',
-    description: '✔ 반전 텍스트 (다크 배경용)',
   },
 ]
 </script>

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -8,69 +8,39 @@
   }
 }
 
-@layer utilities {
-  .bg-brand-primary { background-color: #FFD633; }
-  .hover\:bg-brand-accent:hover { background-color: #FFBC00; }
-  .text-base { color: #000000; }
-  .bg-base { background-color: #FFFFFF; }
-  .border-base { border-color: #EAEAEA; }
-  .hover\:bg-subtle-bg:hover { background-color: #F6F6F6; }
-  .bg-nav-stroke { background-color: #EFEFEF; }
-  .bg-text { background-color: #000000; }
-  .text-inverse { color: #FFFFFF; }
-}
+@layer components {
+  .btn {
+    @apply rounded-xl font-semibold text-center transition duration-200;
+  }
+  .btn-primary {
+    @apply bg-brand-primary text-text-base w-btn-lg-w h-btn-h text-base shadow-sm hover:bg-brand-accent;
+  }
+  .btn-cart {
+    @apply bg-base-bg text-text-base w-btn-md-w h-btn-h text-base border border-base-border hover:bg-subtle-bg;
+  }
+  .btn-buy {
+    @apply bg-brand-primary text-text-base w-btn-md-w h-btn-h text-base hover:bg-brand-accent;
+  }
+  .btn-cancel {
+    @apply bg-nav-stroke text-text-base w-btn-sm-w h-btn-h text-base;
+  }
+  .btn-confirm {
+    @apply bg-brand-primary text-text-base w-btn-sm-w h-btn-h text-base;
+  }
 
-/* 공통 버튼 */
-.btn {
-  @apply rounded-[12px] font-semibold text-center transition duration-200;
-}
-
-/* 1. 기본 주요 버튼 */
-.btn-primary {
-  @apply bg-brand-primary text-base w-[353px] h-[48px] text-[16px] shadow-sm hover:bg-brand-accent;
-}
-
-/* 2. 장바구니 담기 버튼 (화이트 배경 + border) */
-.btn-cart {
-  @apply bg-base text-base w-[169px] h-[48px] text-[16px] border border-base hover:bg-subtle-bg;
-}
-
-/* 2. 바로 구매하기 버튼 (primary 배경) */
-.btn-buy {
-  @apply bg-brand-primary text-base w-[169px] h-[48px] text-[16px] hover:bg-brand-accent;
-}
-
-/* 3. 취소 버튼 (회색 배경) */
-.btn-cancel {
-  @apply bg-nav-stroke text-base w-[140px] h-[48px] text-[16px];
-}
-
-/* 3. 수정 완료 버튼 (primary 배경) */
-.btn-confirm {
-  @apply bg-brand-primary text-base w-[140px] h-[48px] text-[16px];
-}
-
-/* 공통 뱃지 스타일 */
-.badge {
-  @apply rounded-[16px] text-[16px] font-bold w-[80px] h-[24px] flex items-center justify-center;
-}
-
-/* 1. VIP */
-.badge-vip {
-  @apply bg-text text-text-inverse; /* 배경: 검정(#000000), 글씨: 흰색(#FFFFFF) */
-}
-
-/* 2. GOLD */
-.badge-gold {
-  @apply bg-brand-primary; /* 배경: primary, 글씨: 검정(#000000) */
-}
-
-/* 3. SILVER */
-.badge-silver {
-  @apply bg-[#D9D9D9]; /* 배경: #D9D9D9, 글씨: 검정 */
-}
-
-/* 4. WHITE */
-.badge-white {
-  @apply bg-nav-stroke; /* 배경: #EFEFEF, 글씨: 검정 */
+  .badge {
+    @apply rounded-2xl text-base font-bold w-20 h-6 flex items-center justify-center;
+  }
+  .badge-vip {
+    @apply bg-text-base text-text-inverse;
+  }
+  .badge-gold {
+    @apply bg-brand-primary text-text-base;
+  }
+  .badge-silver {
+    @apply bg-[#D9D9D9] text-text-base;
+  }
+  .badge-white {
+    @apply bg-nav-stroke text-text-base;
+  }
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,43 +1,44 @@
-/** @type {import('tailwindcss').Config} */
+// tailwind.config.js
 export default {
-  content: ['./index.html', './src/**/*.{vue,js,ts}'],
+  content: ['./index.html', './src/**/*.{vue,js}'],
   theme: {
     extend: {
-      fontFamily: {
-        sans: ['Pretendard', 'sans-serif'],
-      },
-      theme: {
-        screens: {
-          sm: '393px',
-          md: '430px',
-        },
-      },
       colors: {
-        nav: {
-          active: '#A8A8A8',
-          deactivated: '#A7A7A7',
-          stroke: '#EFEFEF',
-        },
-        subtle: {
-          bg: '#F6F6F6',
-          text: '#808080',
-          border: '#D8D8D8',
-        },
-        text: {
-          base: '#000000',
-          emphasis: '#F50000',
-          inverse: '#FFFFFF',
+        brand: {
+          primary: '#FFD633',
+          accent: '#FFBC00',
         },
         base: {
           bg: '#FFFFFF',
           border: '#EAEAEA',
         },
-        brand: {
-          primary: '#FFD633',
-          accent: '#FFBC00',
+        subtle: {
+          bg: '#F6F6F6',
+          border: '#D8D8D8',
+          text: '#808080',
+        },
+        nav: {
+          stroke: '#EFEFEF',
+          active: '#3A3A3A',
+          deactivated: '#A7A7A7',
+        },
+        text: {
+          base: '#000000',
+          inverse: '#FFFFFF',
+          emphasis: '#F50000',
         },
       },
+      spacing: {
+        'btn-lg-w': '22.06rem',   // 353px
+        'btn-md-w': '10.56rem',   // 169px
+        'btn-sm-w': '8.75rem',    // 140px
+        'btn-h': '3rem',          // 48px
+      },
+      fontFamily: {
+        sans: ['Pretendard', 'sans-serif'],
+      },
+      
     },
-    plugins: [],
   },
+  plugins: [],
 }


### PR DESCRIPTION
## 🔖 PR 유형
- [ ] ✨ 기능 추가
- [x] 🐛 버그 수정
- [x] ♻️ 리팩토링
- [ ] 🧪 테스트 코드 추가
- [ ] 📄 문서 수정
- [ ] 기타

## 📌 개요
Tailwind CSS 기반 디자인 시스템을 정비하기 위해 다음과 같은 리팩토링을 진행했습니다:
- 기존 버튼(.btn-*) 및 뱃지(.badge-*) 스타일을 @layer components 레이어로 이동하고, CSS 변수 및 공통 유틸리티 기반으로 통일함으로써 스타일 일관성과 유지보수성을 개선했습니다.
- Tailwind 설정(tailwind.config.js)에서 불필요한 screens 항목을 제거하고, 색상(colors), 간격(spacing), 폰트(fontFamily) 등의 시스템 전반을 프로젝트에 맞춰 최적화하였습니다.

## 🔧 작업 내용
### tailwind.css
- 버튼과 뱃지 스타일을 @layer utilities에서 @layer components로 이동
- 버튼 및 뱃지의 크기, 색상 등 고정값을 CSS 변수(예: w-btn-lg-w, text-text-base 등)로 대체
- border 및 텍스트 색상도 CSS 변수 클래스로 변경하여 일관성 강화
- 버튼의 border-radius 값을 rounded-xl 등 Tailwind 기본 유틸리티로 변경
- 뱃지의 크기와 폰트 크기 등도 Tailwind 기본 유틸리티 중심으로 수정
- 불필요한 주석 삭제 및 코드 간결화

### tailwind.config.js
- content 경로에서 ts 파일을 제외하여 ['./index.html', './src/**/*.{vue,js}']로 변경
- theme.extend 내부에서 screens 항목 제거
- nav 색상 중 active 색상을 '#A8A8A8'에서 '#3A3A3A'로 변경
- colors 구조는 유지하되 일부 색상 순서 및 위치 조정
- spacing에 버튼 크기별 너비와 높이 속성 추가 (btn-lg-w, btn-md-w, btn-sm-w, btn-h)
- fontFamily.sans를 extend 내로 이동 및 유지
- plugins 배열은 변경 없이 유지

## 📎 관련 이슈
Close #