### PR TITLE
[feat] 팬미팅 페이지 컴포넌트 분리 및 API 연동 구현

### DIFF
--- a/src/api/authApi.js
+++ b/src/api/authApi.js
@@ -8,6 +8,10 @@ const authApi = {
   },
   kakaoLogin: async (code) => {
     const res = await axios.get(`/api/auth/oauth/kakao-login?code=${code}`)
+    const accessToken = res.data.accessToken
+    if (accessToken) {
+      localStorage.setItem('accessToken', accessToken)
+    }
     return res
   },
   requestLogout: async () => {

--- a/src/api/axios.js
+++ b/src/api/axios.js
@@ -1,0 +1,17 @@
+// 추후 필요시 주석 삭제
+// // api/axios.js
+// import axios from 'axios'
+
+// const instance = axios.create({
+//   baseURL: '/api',
+// })
+
+// instance.interceptors.request.use((config) => {
+//   const token = localStorage.getItem('accessToken')
+//   if (token) {
+//     config.headers.Authorization = `Bearer ${token}`
+//   }
+//   return config
+// })
+
+// export default instance

--- a/src/api/fanMeetingApi.js
+++ b/src/api/fanMeetingApi.js
@@ -1,1 +1,6 @@
-// 팬미팅 관련 API
+import axios from '@/api/axios'
+
+export const getFanMeetings = async () => {
+  const res = await axios.get('/fan-meetings')
+  return res.data
+}

--- a/src/api/fanMeetingApi.js
+++ b/src/api/fanMeetingApi.js
@@ -1,4 +1,4 @@
-import axios from '@/api/axios'
+import axios from 'axios'
 
 export const getFanMeetings = async () => {
   const res = await axios.get('/fan-meetings')

--- a/src/components/fanmeeting/FanMeetingCard.vue
+++ b/src/components/fanmeeting/FanMeetingCard.vue
@@ -1,0 +1,20 @@
+<template>
+    <div class="flex items-center w-full h-20 cursor-pointer" @click="$emit('click')">
+      <div class="w-16 h-16 rounded-full bg-gradient-to-br from-purple-400 to-blue-500 overflow-hidden mr-6 flex items-center justify-center">
+        <span class="text-white font-bold text-lg">{{ title.charAt(0) }}</span>
+      </div>
+      <div class="flex-1">
+        <h3 class="text-base font-semibold text-black mb-1">{{ title }}</h3>
+        <p class="text-sm text-gray-500">{{ venueName }}</p>
+      </div>
+    </div>
+  </template>
+  
+  <script setup>
+  defineProps({
+    title: String,
+    venueName: String,
+  })
+  defineEmits(['click'])
+  </script>
+  

--- a/src/components/fanmeeting/FanMeetingList.vue
+++ b/src/components/fanmeeting/FanMeetingList.vue
@@ -1,0 +1,27 @@
+<template>
+    <div class="pl-9 pr-5 pb-24">
+      <div
+        v-for="meeting in meetings"
+        :key="meeting.meetingId"
+        class="mt-6 first:mt-0"
+      >
+        <FanMeetingCard
+          :title="meeting.title"
+          :venueName="meeting.venueName"
+          @click="$emit('click', meeting.meetingId)"
+        />
+      </div>
+      <div v-if="meetings.length === 0" class="flex items-center justify-center h-64">
+        <p class="text-subtle-text text-base">검색 결과가 없습니다.</p>
+      </div>
+    </div>
+  </template>
+  
+  <script setup>
+  import FanMeetingCard from './FanMeetingCard.vue'
+  defineProps({
+    meetings: Array,
+  })
+  defineEmits(['click'])
+  </script>
+  

--- a/src/components/fanmeeting/FanMeetingSearch.vue
+++ b/src/components/fanmeeting/FanMeetingSearch.vue
@@ -1,17 +1,16 @@
 <template>
-    <div class="pt-[68px] mb-7 flex justify-center">
-      <SearchBar ref="searchBarRef" />
-    </div>
-  </template>
-  
-  <script setup>
-  import SearchBar from '@/components/common/SearchBar.vue'
-  import { ref, defineExpose } from 'vue'
-  
-  const searchBarRef = ref(null)
-  
-  defineExpose({
-    searchBarRef,
-  })
-  </script>
-  
+  <div class="pt-[68px] mb-7 flex justify-center">
+    <SearchBar ref="searchBarRef" />
+  </div>
+</template>
+
+<script setup>
+import SearchBar from '@/components/common/SearchBar.vue'
+import { ref, defineExpose } from 'vue'
+
+const searchBarRef = ref(null)
+
+defineExpose({
+  searchBarRef,
+})
+</script>

--- a/src/components/fanmeeting/FanMeetingSearch.vue
+++ b/src/components/fanmeeting/FanMeetingSearch.vue
@@ -1,0 +1,17 @@
+<template>
+    <div class="pt-[68px] mb-7 flex justify-center">
+      <SearchBar ref="searchBarRef" />
+    </div>
+  </template>
+  
+  <script setup>
+  import SearchBar from '@/components/common/SearchBar.vue'
+  import { ref, defineExpose } from 'vue'
+  
+  const searchBarRef = ref(null)
+  
+  defineExpose({
+    searchBarRef,
+  })
+  </script>
+  

--- a/src/pages/reservation/FanMeetingPage.vue
+++ b/src/pages/reservation/FanMeetingPage.vue
@@ -1,99 +1,46 @@
 <template>
-  <div class="w-full min-h-screen bg-base-bg">
-    <!-- Header -->
-    <AppHeader type="logo" title="" />
-
-    <!-- Search Bar -->
-    <div class="pt-[68px] mb-7">
-      <SearchBar ref="searchBarRef" />
-    </div>
-
-    <!-- Influencer List -->
-    <div class="pl-9 pb-24">
-      <template v-if="filteredInfluencers.length > 0">
-        <div
-          v-for="(influencer, index) in filteredInfluencers"
-          :key="influencer.id"
-          :class="['flex items-center cursor-pointer w-full h-16', index > 0 ? 'mt-8' : '']"
-          @click="goToDetail(influencer.id)"
-        >
-          <div v-if="influencer.id === 2" class="w-16 h-16 rounded-full overflow-hidden mr-6">
-            <img
-              src="@/assets/icons/yeodano.svg"
-              :alt="influencer.name"
-              class="w-full h-full object-cover"
-            />
-          </div>
-          <div
-            v-else
-            :class="`w-16 h-16 rounded-full bg-gradient-to-br ${influencer.bgColor} overflow-hidden mr-6`"
-          >
-            <div class="w-full h-full flex items-center justify-center">
-              <span class="text-white font-bold text-lg">{{ influencer.initial }}</span>
-            </div>
-          </div>
-          <div class="flex-1">
-            <h3 class="text-xl font-semibold text-black mb-1">{{ influencer.name }}</h3>
-            <div class="flex items-center text-gray-500 text-base">
-              <svg
-                width="16"
-                height="16"
-                viewBox="0 0 24 24"
-                fill="none"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M21 10C21 17 12 23 12 23S3 17 3 10C3 5.02944 7.02944 1 12 1C16.9706 1 21 5.02944 21 10Z"
-                  stroke="#808080"
-                  stroke-width="1.5"
-                />
-                <circle cx="12" cy="10" r="3" stroke="#808080" stroke-width="1.5" />
-              </svg>
-              <span class="ml-2 text-gray-400">{{ influencer.location }}</span>
-            </div>
-          </div>
-        </div>
-      </template>
-
-      <!-- 검색 결과가 없을 때 -->
-      <div v-else class="flex items-center justify-center h-64">
-        <p class="text-subtle-text text-base">검색 결과가 없습니다.</p>
-      </div>
-    </div>
+ <div class="w-full min-h-screen bg-base-bg">
+    <AppHeader type="logo" />
+    <FanMeetingSearch ref="searchRef" />
+    <FanMeetingList :meetings="filteredMeetings" @click="goToDetail" />
+    <AppNav />
   </div>
-  <AppNav />
 </template>
 
 <script setup>
-import { ref, computed, toValue } from 'vue'
+import { ref, computed, onMounted, defineExpose } from 'vue'
 import { useRouter } from 'vue-router'
-import { influencers } from '@/data/fanMeetingData.js'
+
 import AppHeader from '@/components/layout/AppHeader.vue'
-import SearchBar from '@/components/common/SearchBar.vue'
 import AppNav from '@/components/layout/AppNav.vue'
+import FanMeetingSearch from '@/components/fanmeeting/FanMeetingSearch.vue'
+import FanMeetingList from '@/components/fanmeeting/FanMeetingList.vue'
+import { getFanMeetings } from '@/api/fanMeetingApi'
 
 const router = useRouter()
-const searchBarRef = ref(null)
+const searchRef = ref(null)
+const meetings = ref([])
 
-// 인플루언서 데이터를 ref로 변환
-const influencerList = ref(influencers)
+const onKeywordChange = (val) => {
+  keyword.value = val
+}
 
-const filteredInfluencers = computed(() => {
-  if (!influencerList.value || !Array.isArray(influencerList.value)) {
-    return []
-  }
-  const searchKeyword = toValue(searchBarRef.value?.keyword) || ''
-  if (!searchKeyword) {
-    return influencerList.value
-  }
-  return influencerList.value.filter(
-    (influencer) =>
-      influencer.name.toLowerCase().includes(searchKeyword.toLowerCase()) ||
-      influencer.location.toLowerCase().includes(searchKeyword.toLowerCase()),
+
+const filteredMeetings = computed(() => {
+  const keyword = searchRef.value?.searchBarRef?.keyword || ''
+  return meetings.value.filter((m) =>
+    m.title.toLowerCase().includes(keyword.toLowerCase())
   )
 })
-
 const goToDetail = (id) => {
   router.push(`/reservation/${id}`)
 }
+
+onMounted(async () => {
+  try {
+    meetings.value = await getFanMeetings()
+  } catch (e) {
+    console.error('팬미팅 조회 실패:', e)
+  }
+})
 </script>


### PR DESCRIPTION
## 🔖 PR 유형
- [ ] ✨ 기능 추가
- [ ] 🐛 버그 수정
- [ ] ♻️ 리팩토링
- [ ] 🧪 테스트 코드 추가
- [ ] 📄 문서 수정
- [ ] 기타

## 📌 개요
- 기존 FanMeetingPage.vue 내부의 로직 및 UI를 역할 단위로 컴포넌트 분리
- 팬미팅 목록 조회 API 연동 (`/api/fan-meetings`)
- 검색 기능 구현 (`SearchBar.vue` 연동)
- axios Authorization 헤더 적용

## 🔧 작업 내용
- `FanMeetingSearch.vue`: SearchBar 래핑 컴포넌트로 분리, 가운데 정렬 및 키워드 관리
- `FanMeetingList.vue`: 팬미팅 리스트 렌더링 컴포넌트
- `FanMeetingCard.vue`: 개별 팬미팅 항목 카드 컴포넌트
- `fanMeetingApi.js`: getFanMeetings API 함수 정의
- `SearchBar.vue`: 스타일 유지하며 재사용 가능한 검색 컴포넌트로 구현
- `axios.js`: JWT 토큰 자동 주입을 위한 axios 인스턴스 및 interceptor 설정


## ✅ 체크리스트
- [ ] Postman으로 `/api/fan-meetings` 응답 정상 확인

## 📝 기타 참고 사항
- 추후 Detail / Payment / SeatSelect 페이지도 컴포넌트 분리 예정

## 📎 관련 이슈
Close #49 