### PR TITLE
팬미팅 목록 UI/기능 개선 및 결제/예약 관련 기능 보완

### DIFF
--- a/src/api/fanMeetingApi.js
+++ b/src/api/fanMeetingApi.js
@@ -10,6 +10,20 @@ export const getFanMeetings = async () => {
   return res.data
 }
 
+export const getSubscribedFanMeetings = async (grade = 'GENERAL') => {
+  const res = await api.get('/api/fan-meetings/subscribed', {
+    params: { grade }
+  })
+  return res.data
+}
+
+export const getNonSubscribedFanMeetings = async (grade = 'GENERAL') => {
+  const res = await api.get('/api/fan-meetings/non-subscribed', {
+    params: { grade }
+  })
+  return res.data
+}
+
 export const createFanMeeting = async (payload) => {
   const res = await api.post('/api/fan-meetings', payload)
   return res.data
@@ -23,6 +37,16 @@ export const createFanMeeting = async (payload) => {
 export const fetchSeatsByMeetingId = async (meetingId) => {
   const response = await api.get(`/api/fan-meetings/${meetingId}/seats`)
   return response.data
+}
+
+export const fetchPendingSeatsByMeetingId = async (meetingId) => {
+  try {
+    const response = await api.get(`/api/fan-meetings/${meetingId}/pending-seats`)
+    return response.data
+  } catch (err) {
+    console.warn('pending-seats API가 없습니다. 빈 배열을 반환합니다.')
+    return []
+  }
 }
 
 export const checkIfAlreadyReserved = async (meetingId) => {

--- a/src/components/fanmeeting/main/FanMeetingList.vue
+++ b/src/components/fanmeeting/main/FanMeetingList.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="pl-9 pr-5 pb-24">
+  <div class="pl-9 pr-5 pb-8">
     <div v-for="meeting in meetings" :key="meeting.meetingId" class="mt-6 first:mt-0">
       <FanMeetingCard
         :title="meeting.title"

--- a/src/components/fanmeeting/main/FanMeetingSearch.vue
+++ b/src/components/fanmeeting/main/FanMeetingSearch.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="pt-[68px] mb-7 flex justify-center">
+  <div class="mb-7 flex justify-center">
     <SearchBar ref="searchBarRef" />
   </div>
 </template>

--- a/src/components/fanmeeting/reservation/SeatMap.vue
+++ b/src/components/fanmeeting/reservation/SeatMap.vue
@@ -14,7 +14,7 @@
           <button
             v-for="(seat, seatIndex) in row"
             :key="seatIndex"
-            :disabled="seat.status === 'occupied'"
+            :disabled="seat.status === 'occupied' || seat.status === 'pending'"
             @click="$emit('selectSeat', rowIndex, seatIndex)"
             :class="getSeatClass(seat)"
             :style="getSeatStyle(seat)"
@@ -37,11 +37,12 @@ defineProps({ seatMap: Array, seatRows: Array })
 
 const getSeatClass = (seat) => {
   if (seat.status === 'occupied') return 'cursor-not-allowed border-2'
+  if (seat.status === 'pending') return 'cursor-not-allowed border-2'
   if (seat.selected) return 'border-2'
   return 'bg-white border-2 hover:border-brand-primary'
 }
 const getSeatStyle = (seat) => {
-  if (seat.status === 'occupied')
+  if (seat.status === 'occupied' || seat.status === 'pending')
     return 'background-color: #CCCCCC; border-color: #666666; color: #60584C;'
   if (seat.selected) return 'background-color: #FFE685; border-color: #666666; color: #60584C;'
   return 'border-color: #666666; color: #60584C;'

--- a/src/components/layout/AppNav.vue
+++ b/src/components/layout/AppNav.vue
@@ -47,7 +47,7 @@ const isActive = (path) => {
         <span
           :class="[
             'block text-xs leading-none text-center whitespace-nowrap transition-colors duration-200',
-            isActive(item.path) ? 'text-text-base' : 'text-nav-stroke',
+            isActive(item.path) ? 'text-text-base' : 'text-nav-deactivated',
           ]"
         >
           {{ item.name }}

--- a/src/pages/reservation/FanMeetingDetailPage.vue
+++ b/src/pages/reservation/FanMeetingDetailPage.vue
@@ -13,10 +13,9 @@ const router = useRouter()
 const fanMeetingId = Number(route.params.id)
 
 const fanMeetingData = ref({})
-const userGrade = ref('GENERAL') // 사용자의 실제 멤버십 등급
+const userGrade = ref('GENERAL')
 
 const mapDetail = (raw) => {
-  console.log('🔍 매핑 전 원본 데이터:', raw)
   const d = raw?.data ?? raw
 
   const mapped = {
@@ -44,54 +43,31 @@ const mapDetail = (raw) => {
     whiteOpenTime: d?.whiteOpenTime ?? d?.white_open_time ?? '',
     generalOpenTime: d?.generalOpenTime ?? d?.general_open_time ?? ''
   }
-  
-  console.log('🔍 매핑된 결과:', mapped)
   return mapped
 }
 
 onMounted(async () => {
   try {
-    console.log('🔄 팬미팅 상세 조회 시작, ID:', fanMeetingId)
     const res = await getFanMeetingDetail(fanMeetingId)
-    console.log('📦 팬미팅 상세 API 원본 응답:', res)
     
     fanMeetingData.value = mapDetail(res)
-    console.log('📝 매핑된 팬미팅 데이터:', fanMeetingData.value)
-
+    
     // 사용자의 멤버십 등급 조회 (인플루언서 ID 필요)
     if (fanMeetingData.value.influencerId) {
-      console.log('🔄 멤버십 등급 조회 시작, influencerId:', fanMeetingData.value.influencerId)
       try {
         const subscriptionResponse = await api.get(`/api/memberships/subscription/${fanMeetingData.value.influencerId}`)
-        console.log('📦 사용자 구독 정보 API 응답:', subscriptionResponse.data)
         
         // gradeName을 userGrade로 사용 (VIP, GOLD, SILVER, WHITE, GENERAL)
         userGrade.value = subscriptionResponse.data?.gradeName || 'GENERAL'
-        console.log('🎯 최종 사용자 멤버십 등급:', userGrade.value)
+        
       } catch (gradeError) {
-        console.warn('⚠️ 멤버십 등급 조회 실패, GENERAL로 설정:', gradeError)
-        console.warn('⚠️ 에러 상세:', gradeError.response?.data)
         userGrade.value = 'GENERAL'
       }
     } else {
-      console.warn('⚠️ influencerId가 없어서 멤버십 등급을 GENERAL로 설정')
       userGrade.value = 'GENERAL'
     }
   } catch (e) {
-    console.error('❌ 팬미팅 상세 조회 실패:', e)
-    console.error('❌ 에러 상세:', {
-      status: e.response?.status,
-      statusText: e.response?.statusText,
-      data: e.response?.data,
-      message: e.message,
-      config: {
-        method: e.config?.method,
-        url: e.config?.url,
-        baseURL: e.config?.baseURL
-      }
-    })
-    
-    // 에러가 발생해도 기본값으로 설정
+  
     fanMeetingData.value = {
       title: '팬미팅 로딩 실패',
       description: '팬미팅 정보를 불러올 수 없습니다.',
@@ -123,15 +99,6 @@ const canReserve = computed(() => {
   const serverOpen = fanMeetingData.value.isReservationOpen
   const hasSeats = fanMeetingData.value.availableSeats > 0
   const timeOpen = isOpenByTime.value
-  
-  console.log('🔍 예약 가능 여부 체크:', {
-    serverOpen,
-    hasSeats, 
-    timeOpen,
-    currentTime: new Date().toISOString(),
-    openTime: getCurrentGradeOpenTime.value,
-    grade: userGrade.value
-  })
   
   return (serverOpen || timeOpen) && hasSeats
 })

--- a/src/pages/reservation/FanMeetingDetailPage.vue
+++ b/src/pages/reservation/FanMeetingDetailPage.vue
@@ -1,49 +1,202 @@
 <script setup>
-import { ref, onMounted } from 'vue'
+import { ref, onMounted,computed } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import AppHeader from '@/components/layout/AppHeader.vue'
 import BottomButton from '@/components/common/ButtonNav.vue'
 import FanMeetingProfile from '@/components/fanmeeting/detail/FanMeetingProfile.vue'
 import FanMeetingPoster from '@/components/fanmeeting/detail/FanMeetingPoster.vue'
 import { getFanMeetingDetail } from '@/api/fanMeetingApi'
+import api from '@/api'
 
 const route = useRoute()
 const router = useRouter()
 const fanMeetingId = Number(route.params.id)
 
 const fanMeetingData = ref({})
+const userGrade = ref('GENERAL') // 사용자의 실제 멤버십 등급
 
 const mapDetail = (raw) => {
+  console.log('🔍 매핑 전 원본 데이터:', raw)
   const d = raw?.data ?? raw
 
-  return {
-    meetingId: d.meetingId ?? d.meeting_id,
-    title: d.title,
-    description: d.description,
-    venueName: d.venueName ?? d.venue_name,
-    venueAddress: d.venueAddress ?? d.venue_address,
-    date: d.meetingDate ?? d.meeting_date,
-    venue: d.venueName ?? d.venue_name,
-    influencerName: d.influencerName ?? d.influencer_name ?? '',
-    profileImageUrl: d.profileImageUrl ?? d.profile_image_url ?? '',
-    posterImageUrl: d.posterImageUrl ?? d.poster_image_url ?? '',
-    initial: (d.influencerName ?? d.influencer_name ?? 'F').charAt(0),
+  const mapped = {
+    meetingId: d?.meetingId ?? d?.meeting_id,
+    title: d?.title ?? '팬미팅',
+    description: d?.description ?? '',
+    venueName: d?.venueName ?? d?.venue_name ?? '',
+    venueAddress: d?.venueAddress ?? d?.venue_address ?? '',
+    date: d?.meetingDate ?? d?.meeting_date ?? '',
+    venue: d?.venueName ?? d?.venue_name ?? '',
+    influencerId: d?.influencerId ?? d?.influencer_id ?? null,
+    influencerName: d?.influencerName ?? d?.influencer_name ?? '',
+    profileImageUrl: d?.profileImageUrl ?? d?.profile_image_url ?? '',
+    posterImageUrl: d?.posterImageUrl ?? d?.poster_image_url ?? '',
+    initial: (d?.influencerName ?? d?.influencer_name ?? 'F').charAt(0),
     bgColor: 'from-brand-primary to-brand-accent',
+    // 예약 관련 정보 추가
+    availableSeats: d?.availableSeats ?? d?.available_seats ?? 0,
+    isReservationOpen: d?.isReservationOpen ?? d?.is_reservation_open ?? false,
+    grade: d?.grade ?? 'GENERAL',
+    // 등급별 오픈 시간
+    vipOpenTime: d?.vipOpenTime ?? d?.vip_open_time ?? '',
+    goldOpenTime: d?.goldOpenTime ?? d?.gold_open_time ?? '',
+    silverOpenTime: d?.silverOpenTime ?? d?.silver_open_time ?? '',
+    whiteOpenTime: d?.whiteOpenTime ?? d?.white_open_time ?? '',
+    generalOpenTime: d?.generalOpenTime ?? d?.general_open_time ?? ''
   }
+  
+  console.log('🔍 매핑된 결과:', mapped)
+  return mapped
 }
+
 onMounted(async () => {
   try {
+    console.log('🔄 팬미팅 상세 조회 시작, ID:', fanMeetingId)
     const res = await getFanMeetingDetail(fanMeetingId)
+    console.log('📦 팬미팅 상세 API 원본 응답:', res)
+    
     fanMeetingData.value = mapDetail(res)
-    console.log('detail (mapped):', fanMeetingData.value)
+    console.log('📝 매핑된 팬미팅 데이터:', fanMeetingData.value)
+
+    // 사용자의 멤버십 등급 조회 (인플루언서 ID 필요)
+    if (fanMeetingData.value.influencerId) {
+      console.log('🔄 멤버십 등급 조회 시작, influencerId:', fanMeetingData.value.influencerId)
+      try {
+        const subscriptionResponse = await api.get(`/api/memberships/subscription/${fanMeetingData.value.influencerId}`)
+        console.log('📦 사용자 구독 정보 API 응답:', subscriptionResponse.data)
+        
+        // gradeName을 userGrade로 사용 (VIP, GOLD, SILVER, WHITE, GENERAL)
+        userGrade.value = subscriptionResponse.data?.gradeName || 'GENERAL'
+        console.log('🎯 최종 사용자 멤버십 등급:', userGrade.value)
+      } catch (gradeError) {
+        console.warn('⚠️ 멤버십 등급 조회 실패, GENERAL로 설정:', gradeError)
+        console.warn('⚠️ 에러 상세:', gradeError.response?.data)
+        userGrade.value = 'GENERAL'
+      }
+    } else {
+      console.warn('⚠️ influencerId가 없어서 멤버십 등급을 GENERAL로 설정')
+      userGrade.value = 'GENERAL'
+    }
   } catch (e) {
-    console.error('팬미팅 상세 조회 실패:', e)
+    console.error('❌ 팬미팅 상세 조회 실패:', e)
+    console.error('❌ 에러 상세:', {
+      status: e.response?.status,
+      statusText: e.response?.statusText,
+      data: e.response?.data,
+      message: e.message,
+      config: {
+        method: e.config?.method,
+        url: e.config?.url,
+        baseURL: e.config?.baseURL
+      }
+    })
+    
+    // 에러가 발생해도 기본값으로 설정
+    fanMeetingData.value = {
+      title: '팬미팅 로딩 실패',
+      description: '팬미팅 정보를 불러올 수 없습니다.',
+      influencerId: null,
+      availableSeats: 0,
+      isReservationOpen: false
+    }
   }
 })
 
 const goToSeatSelection = () => {
-  router.push(`/reservation/${fanMeetingId}/seat`)
+  if (canReserve.value) {
+    router.push(`/reservation/${fanMeetingId}/seat`)
+  }
 }
+
+// 현재 시간 기준 예약 가능 여부 (클라이언트 측 검증)
+const isOpenByTime = computed(() => {
+  const openTime = getCurrentGradeOpenTime.value
+  if (!openTime) return true // 오픈 시간이 없으면 항상 오픈으로 간주
+  
+  const now = new Date()
+  const openDate = new Date(openTime)
+  return now >= openDate
+})
+
+// 예약 가능 여부 (서버 값과 클라이언트 검증 모두 확인)
+const canReserve = computed(() => {
+  const serverOpen = fanMeetingData.value.isReservationOpen
+  const hasSeats = fanMeetingData.value.availableSeats > 0
+  const timeOpen = isOpenByTime.value
+  
+  console.log('🔍 예약 가능 여부 체크:', {
+    serverOpen,
+    hasSeats, 
+    timeOpen,
+    currentTime: new Date().toISOString(),
+    openTime: getCurrentGradeOpenTime.value,
+    grade: userGrade.value
+  })
+  
+  return (serverOpen || timeOpen) && hasSeats
+})
+
+// 버튼 텍스트 결정
+const buttonText = computed(() => {
+  if (fanMeetingData.value.availableSeats === 0) {
+    return '잔여 좌석이 없습니다'
+  }
+  const serverOpen = fanMeetingData.value.isReservationOpen
+  const timeOpen = isOpenByTime.value
+  const openTime = getCurrentGradeOpenTime.value
+  
+  if (!serverOpen && !timeOpen && openTime) {
+    const openDate = new Date(openTime)
+    const year = openDate.getFullYear()
+    const month = openDate.getMonth() + 1
+    const day = openDate.getDate()
+    const hours = openDate.getHours().toString().padStart(2, '0')
+    const minutes = openDate.getMinutes().toString().padStart(2, '0')
+    const seconds = openDate.getSeconds().toString().padStart(2, '0')
+    
+    return `${userGrade.value} 등급 오픈: ${year}년 ${month}월 ${day}일 ${hours}:${minutes}:${seconds}`
+  }
+  return '예매하기'
+})
+
+// 사용자 등급에 맞는 오픈 시간 가져오기
+const getCurrentGradeOpenTime = computed(() => {
+  const grade = userGrade.value?.toUpperCase() // fanMeetingData.value.grade 대신 userGrade.value 사용
+  switch (grade) {
+    case 'VIP':
+      return fanMeetingData.value.vipOpenTime
+    case 'GOLD':
+      return fanMeetingData.value.goldOpenTime
+    case 'SILVER':
+      return fanMeetingData.value.silverOpenTime
+    case 'WHITE':
+      return fanMeetingData.value.whiteOpenTime
+    case 'GENERAL':
+    default:
+      return fanMeetingData.value.generalOpenTime
+  }
+})
+
+// 오픈 시간 메시지
+const openTimeMessage = computed(() => {
+  const serverOpen = fanMeetingData.value.isReservationOpen
+  const timeOpen = isOpenByTime.value
+  const openTime = getCurrentGradeOpenTime.value
+  
+  // 서버에서 오픈이 아니고, 시간상으로도 오픈이 아니고, 오픈 시간이 있는 경우에만 표시
+  if (!serverOpen && !timeOpen && openTime) {
+    const openDate = new Date(openTime)
+    const year = openDate.getFullYear()
+    const month = openDate.getMonth() + 1
+    const day = openDate.getDate()
+    const hours = openDate.getHours().toString().padStart(2, '0')
+    const minutes = openDate.getMinutes().toString().padStart(2, '0')
+    const seconds = openDate.getSeconds().toString().padStart(2, '0')
+    
+    return `${userGrade.value} 등급의 오픈 시간은 ${year}년 ${month}월 ${day}일 ${hours}:${minutes}:${seconds} 입니다.`
+  }
+  return ''
+})
 </script>
 
 <template>
@@ -53,9 +206,23 @@ const goToSeatSelection = () => {
     <div class="w-full max-w-[393px] md:max-w-[430px] mx-auto">
       <FanMeetingProfile :meetingId="fanMeetingId" :data="fanMeetingData" />
       <FanMeetingPoster  :meetingId="fanMeetingId" :data="fanMeetingData" />
+      
     </div>
 
-    <BottomButton @click="goToSeatSelection" variant="primary" size="lg">예매하기</BottomButton>
+    <!-- 오픈 시간 안내 메시지 -->
+    <div v-if="openTimeMessage" class="px-5 py-3 mx-5 mb-4 bg-yellow-50 border border-yellow-200 rounded-lg">
+      <p class="text-sm text-yellow-800 text-center">{{ openTimeMessage }}</p>
+    </div>
+
+
+    <BottomButton 
+      @click="goToSeatSelection" 
+      :variant="canReserve ? 'primary' : 'cancel'" 
+      :disabled="!canReserve"
+      size="lg"
+    >
+      {{ buttonText }}
+    </BottomButton>
     <div class="h-40"></div>
   </div>
 </template>

--- a/src/pages/reservation/FanMeetingPage.vue
+++ b/src/pages/reservation/FanMeetingPage.vue
@@ -1,49 +1,130 @@
 <template>
- <div class="w-full min-h-screen bg-base-bg">
+  <div class="w-full min-h-screen bg-base-bg">
     <AppHeader type="logo" />
-    <FanMeetingSearch ref="searchRef" />
-    <FanMeetingList :meetings="filteredMeetings" @click="goToDetail" />
+
+    <!-- 고정된 검색창 -->
+    <div
+      class="fixed top-[48px] left-0 right-0 z-10 bg-base-bg transition-transform duration-300"
+      :class="{ 'transform -translate-y-full': !showSearchBar }"
+      ref="searchContainer"
+    >
+      <div class="fixed left-0 right-0 z-10 bg-base-bg ">
+        <div class="pt-3 mb-2 flex justify-center">
+          <SearchBar ref="searchBarRef" />
+        </div>
+      </div>
+    </div>
+
+    <!-- 스페이서 (검색창 높이만큼) -->
+    <div class="h-[120px]"></div>
+
+    <!-- 구독한 인플루언서의 팬미팅 -->
+    <div v-if="filteredSubscribedMeetings.length > 0">
+      <h2 class="text-md font-semibold text-text-base mb-3 pt-3 pl-10">구독 중인 인플루언서</h2>
+      <FanMeetingList :meetings="filteredSubscribedMeetings" @click="goToDetail" />
+    </div>
+
+    <!-- 구독하지 않은 인플루언서의 팬미팅 -->
+    <div v-if="filteredNonSubscribedMeetings.length > 0">
+      <h2 class="text-md font-semibold text-text-base mb-3 pl-10">모든 인플루언서</h2>
+      <FanMeetingList :meetings="filteredNonSubscribedMeetings" @click="goToDetail" />
+    </div>
+
+    <!-- 검색 결과가 없을 때 -->
+    <div
+      v-if="filteredSubscribedMeetings.length === 0 && filteredNonSubscribedMeetings.length === 0"
+      class="px-5 py-10 text-center text-subtle-text"
+    >
+      팬미팅이 없습니다.
+    </div>
+
     <AppNav />
   </div>
 </template>
 
 <script setup>
-import { ref, computed, onMounted } from 'vue'
+import { ref, computed, onMounted, onUnmounted } from 'vue'
 import { useRouter } from 'vue-router'
 
 import AppHeader from '@/components/layout/AppHeader.vue'
 import AppNav from '@/components/layout/AppNav.vue'
-import FanMeetingSearch from '@/components/fanmeeting/main/FanMeetingSearch.vue'
+import SearchBar from '@/components/common/SearchBar.vue'
 import FanMeetingList from '@/components/fanmeeting/main/FanMeetingList.vue'
-import { getFanMeetings } from '@/api/fanMeetingApi'
+import { getSubscribedFanMeetings, getNonSubscribedFanMeetings } from '@/api/fanMeetingApi'
 
 const router = useRouter()
-const searchRef = ref(null)
-const meetings = ref([])
+const searchBarRef = ref(null)
+const searchContainer = ref(null)
+const subscribedMeetings = ref([])
+const nonSubscribedMeetings = ref([])
+const showSearchBar = ref(true)
+const lastScrollY = ref(0)
 
-// 검색 키워드 변경 핸들러 (현재 미사용)
-
-
-const filteredMeetings = computed(() => {
-  const keyword = searchRef.value?.searchBarRef?.keyword || ''
-  if (!Array.isArray(meetings.value)) {
+// 구독한 인플루언서의 팬미팅 필터링
+const filteredSubscribedMeetings = computed(() => {
+  const keyword = searchBarRef.value?.keyword || ''
+  if (!Array.isArray(subscribedMeetings.value)) {
     return []
   }
-  return meetings.value.filter((m) =>
-    m.title.toLowerCase().includes(keyword.toLowerCase())
+  return subscribedMeetings.value.filter((m) =>
+    m.title.toLowerCase().includes(keyword.toLowerCase()),
   )
 })
+
+// 구독하지 않은 인플루언서의 팬미팅 필터링
+const filteredNonSubscribedMeetings = computed(() => {
+  const keyword = searchBarRef.value?.keyword || ''
+  if (!Array.isArray(nonSubscribedMeetings.value)) {
+    return []
+  }
+  return nonSubscribedMeetings.value.filter((m) =>
+    m.title.toLowerCase().includes(keyword.toLowerCase()),
+  )
+})
+
+// 스크롤 이벤트 처리
+const handleScroll = () => {
+  const currentScrollY = window.scrollY
+
+  if (currentScrollY < 50) {
+    // 최상단 근처에서는 항상 검색창 표시
+    showSearchBar.value = true
+  } else if (currentScrollY > lastScrollY.value) {
+    showSearchBar.value = false
+  } else {
+    // 위로 스크롤: 검색창 표시
+    showSearchBar.value = true
+  }
+
+  lastScrollY.value = currentScrollY
+}
+
 const goToDetail = (id) => {
   router.push(`/reservation/${id}`)
 }
 
 onMounted(async () => {
   try {
-    const result = await getFanMeetings()
-    meetings.value = Array.isArray(result) ? result : []
-  } catch (e) {
-    console.error('팬미팅 조회 실패:', e)
-    meetings.value = []
+    const [subscribedResult, nonSubscribedResult] = await Promise.all([
+      getSubscribedFanMeetings('GENERAL'),
+      getNonSubscribedFanMeetings('GENERAL'),
+    ])
+
+    subscribedMeetings.value = Array.isArray(subscribedResult) ? subscribedResult : []
+    nonSubscribedMeetings.value = Array.isArray(nonSubscribedResult) ? nonSubscribedResult : []
+
+    } catch (e) {
+    console.error('❌ 팬미팅 조회 실패:', e)
+    subscribedMeetings.value = []
+    nonSubscribedMeetings.value = []
   }
+
+  // 스크롤 이벤트 리스너 추가
+  window.addEventListener('scroll', handleScroll, { passive: true })
+})
+
+onUnmounted(() => {
+  // 스크롤 이벤트 리스너 제거
+  window.removeEventListener('scroll', handleScroll)
 })
 </script>

--- a/src/pages/reservation/FanMeetingPage.vue
+++ b/src/pages/reservation/FanMeetingPage.vue
@@ -25,10 +25,11 @@
     </div>
 
     <!-- 구독하지 않은 인플루언서의 팬미팅 -->
-    <div v-if="filteredNonSubscribedMeetings.length > 0">
-      <h2 class="text-md font-semibold text-text-base mb-3 pl-10">모든 인플루언서</h2>
-      <FanMeetingList :meetings="filteredNonSubscribedMeetings" @click="goToDetail" />
-    </div>
+    <div v-if="filteredNonSubscribedMeetings.length > 0" class="pb-20">
+  <h2 class="text-md font-semibold text-text-base mb-3 pl-10">모든 인플루언서</h2>
+  <FanMeetingList :meetings="filteredNonSubscribedMeetings" @click="goToDetail" />
+</div>
+
 
     <!-- 검색 결과가 없을 때 -->
     <div

--- a/src/pages/reservation/FanMeetingPaymentPage.vue
+++ b/src/pages/reservation/FanMeetingPaymentPage.vue
@@ -96,7 +96,7 @@ const currentFanMeeting = ref({
   venue: '장소 미정',
 })
 
-const ticketPrice = ref(33000)
+const ticketPrice = ref(20000)
 const serviceFee = ref(3000)
 const selectedPaymentMethod = ref('TOSSPAY')
 const isProcessing = ref(false)


### PR DESCRIPTION
## 🔖 PR 유형
- [ ] ✨ 기능 추가
- [ ] 🐛 버그 수정
- [ ] ♻️ 리팩토링
- [ ] 🧪 테스트 코드 추가
- [ ] 📄 문서 수정
- [ ] 기타

## 📌 개요
이번 PR에서는 팬미팅 목록 UI를 사용자 경험 중심으로 개선하고, 결제 및 좌석 예약 기능을 보완하였습니다. 구독한 인플루언서와 비구독 인플루언서의 팬미팅을 분리 표시하여 가독성을 높였으며, 각 목록에 독립적인 검색 기능을 적용하였습니다. 검색창은 화면 상단에 고정되도록 구현하고, 스크롤 방향에 따라 부드럽게 숨김·표시되도록 하여 접근성을 강화했습니다. 또한 멤버십 등급별 예약 오픈 시간 및 예약 가능 여부를 명확히 표시하고, 토스페이먼츠 결제 API 호출 방식을 수정하여 안정성을 높였습니다. 좌석 상태를 실시간으로 업데이트하도록 구현해 사용자 혼선을 줄였으며, UI 하단 패딩 추가와 스타일 보완을 통해 가려지는 문제를 해결하였습니다.


## 🔧 작업 내용
### 1. 팬미팅 목록 개선
- 구독/비구독 인플루언서 팬미팅 분리 표시
- `getSubscribedFanMeetings`, `getNonSubscribedFanMeetings` API 연동
- 각 섹션별 독립 검색 기능 적용
- 검색창 `fixed` 포지션 적용 및 스크롤시에도 검색창 고정되도록 구현

### 2. 결제/예약 기능 보완
- 토스페이먼츠 결제 API 호출 방식 수정
- 멤버십 등급별 예약 오픈 시간 표시 (VIP, GOLD, SILVER, WHITE, GENERAL)
- 사용자 실제 멤버십 등급 조회 API 연동 및 버튼 텍스트 반영
- 좌석 상태 실시간 업데이트 (`pending` 상태 표시, 페이지 포커스/재방문 시 자동 새로고침)

### 3. UI 및 코드 정리
- 하단 `AppNav`에 가려지지 않도록 `pb` 값 조정 및 맨 하단 패딩 추가
- AppNav `deactivated` 색상 미적용 문제 해결
- 불필요한 디버그 코드 삭제

## ✅ 체크리스트

<img width="375" height="794" alt="image" src="https://github.com/user-attachments/assets/1c493726-5ce1-49a8-b4ef-b1319cb6fdf7" />

<img width="366" height="399" alt="image" src="https://github.com/user-attachments/assets/651d4643-97af-4f93-9f78-b80ef87d7a96" />

1. 
<img width="366" height="782" alt="image" src="https://github.com/user-attachments/assets/345e67d5-9df7-4f39-a6f0-b59f68de2ef8" />

2. 
<img width="361" height="777" alt="image" src="https://github.com/user-attachments/assets/972392d0-cc8e-4c83-aa2c-e60776f8e111" />

3. 
<img width="363" height="779" alt="image" src="https://github.com/user-attachments/assets/6c7d12cf-893d-48ff-ae29-4e699c172959" />

## 📝 기타 참고 사항
- 팬미팅 더 손봐야하는데 이거 그냥 끝도 없습니다 답이 없어요 시간이 없어요

## 📎 관련 이슈
Closes #99 
Closes #98 
Closes #97