### PR TITLE
[feat] 멤버십 결제 연동 구현 #81

### DIFF
--- a/public/firebase-messaging-sw.js
+++ b/public/firebase-messaging-sw.js
@@ -35,7 +35,7 @@ messaging.onBackgroundMessage((payload) => {
 self.addEventListener('notificationclick', (event) => {
   console.log('[FCM SW] 알림 클릭:', event)
   event.notification.close()
-  
+
   const url = event.notification.data?.url || '/'
   event.waitUntil(
     clients.matchAll({ type: 'window', includeUncontrolled: true }).then((clientList) => {

--- a/src/api/membershipApi.js
+++ b/src/api/membershipApi.js
@@ -1,1 +1,24 @@
 // 멤버십 관련 API
+
+import api from '@/api'
+
+/**
+ * 멤버십 구독 신청
+ * payload: { influencerId:number, gradeId:number, autoRenewal:boolean, monthlyAmount?:number, payMethod?:string }
+ * 응답: { membershipId, influencerId, gradeId, status, monthlyAmount, paymentId, paymentPageUrl, ... }
+ */
+
+export const subscribeMembership = (payload) =>
+  api.post('/api/memberships/subscribe', payload).then(res => res.data)
+
+/** 멤버십 등급 목록 */
+export const getMembershipGrades = () =>
+  api.get('/api/memberships/grades').then(res => res.data)
+
+/** 내 멤버십 요약 정보 */
+export const getMyMembershipInfo = () =>
+  api.get('/api/memberships/my-info').then(res => res.data)
+
+/** 특정 인플루언서에 대한 나의 구독 정보 */
+export const getUserSubscriptionByInfluencer = (influencerId) =>
+  api.get(`/api/memberships/subscription/${influencerId}`).then(res => res.data)

--- a/src/fcm-init.js
+++ b/src/fcm-init.js
@@ -59,26 +59,26 @@ export async function initFcm({ force = false } = {}) {
     if (!messageHandlerBound) {
       let lastNotificationTime = 0
       const NOTIFICATION_THROTTLE = 2000 // 2초 내 중복 알림 방지
-      
+
       bindForegroundMessage((payload) => {
         console.log('[FCM] 포그라운드 메시지 수신:', payload)
-        
+
         const now = Date.now()
         if (now - lastNotificationTime < NOTIFICATION_THROTTLE) {
           console.log('[FCM] 중복 알림 방지 - 무시됨')
           return
         }
-        
+
         const title = payload.notification?.title || '알림'
         const body = payload.notification?.body || ''
         const url = payload.fcmOptions?.link || payload.data?.targetUrl || '/'
-        
+
         console.log('[FCM] 포그라운드 알림 표시:', title)
         lastNotificationTime = now
-        
+
         // 포그라운드에서만 알림 표시
         if (Notification.permission === 'granted') {
-          const notification = new Notification(title, { 
+          const notification = new Notification(title, {
             body,
             icon: '/logo.svg',
             badge: '/logo.svg',

--- a/src/pages/MembershipSelect.vue
+++ b/src/pages/MembershipSelect.vue
@@ -1,8 +1,18 @@
 <script setup>
+/**
+ * 멤버십 선택 → 결제 요청 페이지 이동
+ * 변경점 요약
+ * - subscribeMembership 응답에서 membershipId/paymentId/amount를 받아서
+ *   공통 결제 페이지(PaymentPage)가 읽을 수 있도록 쿼리로 넘김
+ *   ?paymentType=MEMBERSHIP&membershipId=...&paymentId=...&amount=...
+ * - 금액은 반드시 서버가 내려준 값을 우선 사용 (UI 표시 금액과 불일치 방지)
+ */
+
 import { ref, onMounted, computed } from 'vue'
-import { useRoute } from 'vue-router'
+import { useRoute, useRouter } from 'vue-router'
 import { useInfluencerStore } from '@/stores/influencerStore'
 import influencerApi from '@/api/influencerApi'
+import { subscribeMembership } from '@/api/membershipApi'
 
 import AppHeader from '@/components/layout/AppHeader.vue'
 import MembershipProfile from '@/components/membership/MembershipProfile.vue'
@@ -11,31 +21,37 @@ import MembershipTierSelect from '@/components/membership/MembershipTierSelect.v
 import BasePaymentOption from '@/components/common/BasePaymentOption.vue'
 import BaseButton from '@/components/common/BaseButton.vue'
 
-const selectedTier = ref('VIP') // 초기값도 대문자로
+// 결제수단(공통 컴포넌트 규약 유지)
+const selectedTier = ref('VIP') // 대문자 비교용
 const selectedPayment = ref('kb')
 
 const route = useRoute()
+const router = useRouter()
 const influencerStore = useInfluencerStore()
 
+// 인플루언서 정보
 const influencerName = computed(() => influencerStore.name)
-const profileImage   = computed(() => influencerStore.profileImage)
-const description    = computed(() => influencerStore.description)
+const profileImage = computed(() => influencerStore.profileImage)
+const description = computed(() => influencerStore.description)
 
-// ✅ 등급 리스트 상태
+// 등급 리스트
 const grades = ref([])
 
-// 비교 시 대소문자 무시, 표시 시 대문자
+/** 현재 선택된 등급의 금액 (표시용) */
 const selectedAmount = computed(() => {
-  const found = grades.value.find(
-    g => String(g.gradeName).toUpperCase() === selectedTier.value
-  )
+  const found = grades.value.find((g) => String(g.gradeName).toUpperCase() === selectedTier.value)
   return found ? found.monthlyAmount : 0
+})
+
+/** 현재 선택된 등급의 gradeId */
+const selectedGradeId = computed(() => {
+  const found = grades.value.find((g) => String(g.gradeName).toUpperCase() === selectedTier.value)
+  return found ? found.gradeId : null
 })
 
 onMounted(async () => {
   try {
     const influencerId = route.params.influencerId
-
     const resp = await influencerApi.fetchDetail(influencerId)
     const data = resp?.data ?? resp
     console.log('🔥 detail data:', data)
@@ -46,11 +62,9 @@ onMounted(async () => {
     }
 
     influencerStore.setInfluencer(data)
-
     grades.value = data.membershipGrades ?? data.grades ?? []
     console.log('grades set:', grades.value)
 
-    // 로딩 후 초기 선택값도 대문자로
     if (grades.value.length) {
       selectedTier.value = String(grades.value[0].gradeName).toUpperCase()
     }
@@ -58,6 +72,58 @@ onMounted(async () => {
     console.error('❌ 인플루언서 상세 조회 실패', e)
   }
 })
+
+/**
+ * 결제 버튼 클릭
+ * 1) 백엔드에 멤버십 구독(결제 준비) 요청
+ * 2) 공통 결제 페이지(PaymentPage)로 이동하면서 필요한 식별자/금액을 쿼리로 전달
+ *    - paymentType=MEMBERSHIP
+ *    - membershipId
+ *    - paymentId
+ *    - amount(서버 응답 금액)
+ */
+const goToPayment = async () => {
+  if (!selectedPayment.value) return
+  if (!selectedGradeId.value) {
+    alert('등급을 선택해 주세요.')
+    return
+  }
+
+  try {
+    // 1) 백엔드에 멤버십 구독(결제 준비) 요청
+    const res = await subscribeMembership({
+      influencerId: Number(route.params.influencerId),
+      gradeId: selectedGradeId.value,
+      autoRenewal: true,
+      monthlyAmount: selectedAmount.value, // 서버가 최종 검증
+      payMethod: 'TOSSPAY',
+    })
+
+    // ✅ 백엔드 응답에서 필요한 값
+    const paymentId = res.paymentId
+    const amount = res.monthlyAmount ?? res.amount ?? selectedAmount.value
+
+    if (!paymentId) {
+      console.error('❌ paymentId 누락:', res)
+      alert('결제 준비에 실패했어요. 다시 시도해 주세요.')
+      return
+    }
+
+    // 2) 공통 PaymentPage의 "재사용 분기"를 강제로 태움
+    //    (조건: route.query.paymentId && paymentType === 'RESERVATION')
+    router.push({
+      name: 'PaymentPage', // == '/payments/request'
+      query: {
+        paymentType: 'RESERVATION', // 🔴 중요: 재사용 분기 트리거
+        paymentId: String(paymentId), // 🔴 중요: 기존 payment 재사용
+        amount: String(amount), // PaymentPage가 표시/요청에 사용
+      },
+    })
+  } catch (e) {
+    console.error('구독 신청 실패:', e)
+    alert(e?.response?.data?.message ?? '구독 신청에 실패했어요.')
+  }
+}
 </script>
 
 <template>
@@ -77,16 +143,14 @@ onMounted(async () => {
       </div>
 
       <div class="bg-base-bg rounded-xl shadow p-4 mt-5">
-        <MembershipTierSelect
-          v-model:select-tier="selectedTier"
-          :grades="grades"
-        />
+        <MembershipTierSelect v-model:select-tier="selectedTier" :grades="grades" />
       </div>
 
       <div class="bg-base-bg rounded-xl shadow p-4 mt-5 mb-20">
         <BasePaymentOption v-model="selectedPayment" />
       </div>
 
+      <!-- 하단 고정 결제 버튼 -->
       <nav
         class="fixed bottom-0 left-0 w-full h-20 bg-base-bg border-t border-nav-stroke rounded-t-2xl flex items-center justify-center z-50"
       >
@@ -94,6 +158,7 @@ onMounted(async () => {
           :variant="selectedPayment ? 'primary' : 'cancel'"
           size="lg"
           :disabled="!selectedPayment"
+          @click="goToPayment"
         >
           <span class="font-bold">{{ selectedAmount.toLocaleString() }} 원</span>
           <span class="font-bold">결제하기</span>


### PR DESCRIPTION
## 🔖 PR 유형
- [x] ✨ 기능 추가
- [ ] 🐛 버그 수정
- [ ] ♻️ 리팩토링
- [ ] 🧪 테스트 코드 추가
- [ ] 📄 문서 수정
- [ ] 기타

## 📌 개요
멤버십 신청 결제 연동하였습니다

## 🔧 작업 내용
- 원하는 멤버십 및 결제 방법 선택 후 결제하기 버튼 클릭 시 토스페이 결제로 넘어감


## 📝 기타 참고 사항
- 결제 성공 후 팬카드에 업로드 되는지 확인하기

## 📎 관련 이슈
Close #81 