### PR TITLE
[feat] 팬카드 상세 페이지 기능 개선 - 구독 취소 및 추억 기능

### DIFF
--- a/src/api/membershipApi.js
+++ b/src/api/membershipApi.js
@@ -22,3 +22,7 @@ export const getMyMembershipInfo = () =>
 /** 특정 인플루언서에 대한 나의 구독 정보 */
 export const getUserSubscriptionByInfluencer = (influencerId) =>
   api.get(`/api/memberships/subscription/${influencerId}`).then(res => res.data)
+
+/** 멤버십 구독 취소 */
+export const cancelMembership = (membershipId) =>
+  api.delete(`/api/memberships/${membershipId}/cancel`).then(res => res.data)

--- a/vite.config.js
+++ b/vite.config.js
@@ -15,6 +15,7 @@ export default defineConfig({
   },
   plugins: [
     vue(),
+    vueDevTools(),
     VitePWA({
       registerType: 'autoUpdate', // 새 버전 자동 갱신
       includeAssets: ['favicon.ico', 'apple-touch-icon.png'],


### PR DESCRIPTION
## 🔖 PR 유형
- [x] ✨ 기능 추가
- [x] 🐛 버그 수정
- [x] ♻️ 리팩토링
- [ ] 🧪 테스트 코드 추가
- [ ] 📄 문서 수정
- [ ] 기타

## 📌 개요
작업 목적을 간단히 설명해주세요.

## 🔧 작업 내용
  1. 구독 취소: 실제 멤버십 ID를 사용한 정확한 구독 취소
  2. 추억 표시: 결제 히스토리를 사용자 친화적인 "추억" 형태로 변환
  3. UI 개선: 팬카드 메인 페이지 배경색 통일 (흰색)
  4. API 표준화: membershipApi.js에 cancelMembership 함수 추가

## ✅ 체크리스트
추억 탭
<img width="426" height="934" alt="image" src="https://github.com/user-attachments/assets/abe1557f-2b1e-4cb3-80f8-e2d24996367f" />


## 📝 기타 참고 사항
추억 탭 프론트 피그마 디자인 확정되면 변경 필요
