### PR TITLE
[feat] 팬미팅 예약 표시 및 모바일 티켓 UX 개선

### DIFF
--- a/src/api/fanMeetingApi.js
+++ b/src/api/fanMeetingApi.js
@@ -90,3 +90,9 @@ export const uploadFanMeetingPoster = async (file, influencerId) => {
   // data가 문자열 URL
 return { url: data }
 }
+
+// 사용자의 특정 인플루언서 팬미팅 예약 여부 확인
+export const checkUpcomingMeetingWithInfluencer = async (influencerId) => {
+  const res = await api.get(`/api/fan-meetings/user/${influencerId}/upcoming`)
+  return res.data
+}

--- a/src/api/fanMeetingApi.js
+++ b/src/api/fanMeetingApi.js
@@ -96,3 +96,9 @@ export const checkUpcomingMeetingWithInfluencer = async (influencerId) => {
   const res = await api.get(`/api/fan-meetings/user/${influencerId}/upcoming`)
   return res.data
 }
+
+// 사용자의 모든 팬미팅 예약 여부 확인 (인플루언서 상관없이)
+export const checkAnyUpcomingMeeting = async () => {
+  const res = await api.get('/api/fan-meetings/user/upcoming')
+  return res.data
+}

--- a/src/pages/fancard/FanCardDetailPage.vue
+++ b/src/pages/fancard/FanCardDetailPage.vue
@@ -29,15 +29,15 @@ const goToTicket = (fanMeetingId) => {
   console.log('🎫 모바일 티켓으로 이동:', {
     fanMeetingId,
     reservationId: fanCard.value?.reservationId,
-    seatId: fanCard.value?.seatId
+    seatId: fanCard.value?.seatId,
   })
-  
+
   router.push({
     path: '/fancard/mobile-ticket',
-    query: { 
+    query: {
       fanMeetingId,
       reservationId: fanCard.value?.reservationId,
-      seatId: fanCard.value?.seatId
+      seatId: fanCard.value?.seatId,
     },
   })
 }
@@ -84,7 +84,7 @@ const fetchFancardDetail = async () => {
       membershipStatus: data.membership?.status || 'UNKNOWN', // 멤버십 상태
       influencer: data.influencer, // 인플루언서 정보 추가
     }
-    
+
     // 팬미팅 예약 여부 확인
     await checkFanMeetingReservation()
   } catch (err) {
@@ -99,21 +99,21 @@ const checkFanMeetingReservation = async () => {
   console.log('🔍 팬미팅 예약 확인 시작', {
     fanCard: fanCard.value,
     influencer: fanCard.value?.influencer,
-    influencerId: fanCard.value?.influencer?.influencerId
+    influencerId: fanCard.value?.influencer?.influencerId,
   })
-  
+
   if (!fanCard.value?.influencer?.influencerId) {
     console.warn('⚠️ influencerId가 없어서 팬미팅 예약 확인을 건너뜁니다')
     return
   }
-  
+
   try {
     isCheckingMeeting.value = true
     console.log('📡 API 호출:', fanCard.value.influencer.influencerId)
     const response = await checkUpcomingMeetingWithInfluencer(fanCard.value.influencer.influencerId)
     console.log('📡 API 응답:', response)
     hasUpcomingMeeting.value = response.hasUpcomingMeeting || false
-    
+
     // 팬미팅 ID, 예약 ID, 좌석 ID를 fanCard에 저장 (API 응답에 포함되어야 함)
     if (response.meetingId) {
       fanCard.value.fanMeetingId = response.meetingId
@@ -124,7 +124,7 @@ const checkFanMeetingReservation = async () => {
     if (response.seatId) {
       fanCard.value.seatId = response.seatId
     }
-    
+
     console.log('✅ 팬미팅 예약 여부:', hasUpcomingMeeting.value)
   } catch (err) {
     console.error('❌ 팬미팅 예약 확인 실패:', err)
@@ -321,7 +321,7 @@ onMounted(() => {
 
     <!-- 2. 예약 안내 배너 (20px 아래) - 조건부 표시 -->
     <div
-      v-if="hasUpcomingMeeting && (fanCard.isActive && fanCard.membershipStatus === 'ACTIVE')"
+      v-if="hasUpcomingMeeting && fanCard.isActive && fanCard.membershipStatus === 'ACTIVE'"
       class="mx-5 mt-5 h-[47px] bg-base-bg rounded-lg shadow-md flex flex-col items-center justify-center text-xs font-semibold text-center"
     >
       예약한 팬미팅 내역이 있어요.<br />
@@ -332,7 +332,7 @@ onMounted(() => {
         바로 확인하기
       </span>
     </div>
-    
+
     <!-- 팬미팅 예약 확인 중 로딩 -->
     <div
       v-if="isCheckingMeeting"
@@ -394,8 +394,8 @@ onMounted(() => {
     </div>
 
     <!-- 5. 구독 히스토리 -->
-    <div class="mx-5 mt-5 bg-base-bg rounded-lg shadow-md px-[11px] py-4 pl-5">
-      <div class="flex items-center mb-2 gap-2 border-b border-subtle-border pb-2">
+    <div class="mx-5 mt-5 bg-base-bg rounded-lg shadow-md px-[11px] pt-4 pl-5">
+      <div class="flex items-center gap-2 border-b border-subtle-border pb-2">
         <img :src="iconFanzip" class="w-5 h-5" alt="추억" />
         <h3 class="font-semibold text-base">{{ fanCard.nickname }}님와의 추억</h3>
       </div>
@@ -407,7 +407,6 @@ onMounted(() => {
           <img v-else-if="item.title.includes('해지')" :src="BrokenHeart" />
           <div>
             <p :class="{ 'font-bold': item.bold }">{{ item.title }}</p>
-            <p v-if="item.amount" class="text-base">{{ item.amount.toLocaleString() }}원</p>
             <p class="text-xs mt-[1px]">{{ item.date }}</p>
           </div>
         </li>

--- a/src/pages/fancard/FanCardDetailPage.vue
+++ b/src/pages/fancard/FanCardDetailPage.vue
@@ -6,7 +6,7 @@ import AppNav from '@/components/layout/AppNav.vue'
 import AppHeader from '@/components/layout/AppHeader.vue'
 import { fancardApi } from '@/api/fancardApi'
 import { cancelMembership } from '@/api/membershipApi'
-import { checkUpcomingMeetingWithInfluencer } from '@/api/fanMeetingApi'
+import { checkUpcomingMeetingWithInfluencer, checkAnyUpcomingMeeting } from '@/api/fanMeetingApi'
 import { useAuthStore } from '@/stores/authStore'
 
 import tomoTomoImg from '@/assets/fancard/TomoTomo.svg'
@@ -109,7 +109,7 @@ const checkFanMeetingReservation = async () => {
 
   try {
     isCheckingMeeting.value = true
-    console.log('📡 API 호출:', fanCard.value.influencer.influencerId)
+    console.log('📡 특정 인플루언서 팬미팅 예약 확인 API 호출:', fanCard.value.influencer.influencerId)
     const response = await checkUpcomingMeetingWithInfluencer(fanCard.value.influencer.influencerId)
     console.log('📡 API 응답:', response)
     hasUpcomingMeeting.value = response.hasUpcomingMeeting || false
@@ -160,12 +160,27 @@ const formatBenefits = (benefits) => {
 }
 
 const formatPaymentHistory = (paymentHistory) => {
-  return paymentHistory.map((payment) => ({
-    title: payment.title || '결제 완료',
-    amount: payment.amount,
-    date: formatDate(payment.paymentDate || payment.paidAt),
-    bold: payment.bold || false,
-  }))
+  return paymentHistory.map((payment) => {
+    let title = payment.title || '결제 완료'
+    
+    // 인플루언서 이름 제거 (예: "토모토모 상품 구매" → "상품 구매")
+    title = title.replace(/^[^\s]+ /, '')
+    
+    // 멤버십 관련 문구 변경
+    if (title.includes('멤버십 해지')) {
+      title = title.replace('멤버십 해지', '구독 해지')
+    }
+    if (title.includes('멤버십 구독')) {
+      title = title.replace('멤버십 구독', '구독 시작')
+    }
+    
+    return {
+      title,
+      amount: payment.amount,
+      date: formatDate(payment.paymentDate || payment.paidAt),
+      bold: payment.bold || false,
+    }
+  })
 }
 
 const imageError = ref(false)
@@ -400,14 +415,34 @@ onMounted(() => {
         <h3 class="font-semibold text-base">{{ fanCard.nickname }}님와의 추억</h3>
       </div>
       <ul class="divide-y divide-subtle-border text-sm">
-        <li v-for="(item, idx) in fanCard.history" :key="idx" class="py-2 flex gap-4">
-          <img v-if="item.title.includes('결제')" :src="Heart" />
-          <img v-else-if="item.title.includes('예매')" :src="Ticket" />
-          <img v-else-if="item.title.includes('구매')" :src="Cart" />
-          <img v-else-if="item.title.includes('해지')" :src="BrokenHeart" />
-          <div>
-            <p :class="{ 'font-bold': item.bold }">{{ item.title }}</p>
-            <p class="text-xs mt-[1px]">{{ item.date }}</p>
+        <li v-for="(item, idx) in fanCard.history" :key="idx" class="py-2 flex gap-4 items-center">
+          <img 
+            v-if="item.title.includes('결제') || item.title.includes('구독')" 
+            :src="Heart" 
+            class="w-5 h-5 flex-shrink-0" 
+            alt="구독 아이콘"
+          />
+          <img 
+            v-else-if="item.title.includes('예매')" 
+            :src="Ticket" 
+            class="w-5 h-5 flex-shrink-0" 
+            alt="예매 아이콘"
+          />
+          <img 
+            v-else-if="item.title.includes('구매')" 
+            :src="Cart" 
+            class="w-5 h-5 flex-shrink-0" 
+            alt="구매 아이콘"
+          />
+          <img 
+            v-else-if="item.title.includes('해지')" 
+            :src="BrokenHeart" 
+            class="w-5 h-5 flex-shrink-0" 
+            alt="해지 아이콘"
+          />
+          <div class="flex-1">
+            <p class="font-semibold">{{ item.title }}</p>
+            <p class="text-xs mt-[1px] text-subtle-text">{{ item.date }}</p>
           </div>
         </li>
       </ul>

--- a/src/pages/fancard/FanCardPage.vue
+++ b/src/pages/fancard/FanCardPage.vue
@@ -359,24 +359,6 @@ onMounted(() => {
 
     <!-- 메인 컨텐츠 영역: 헤더와 네비게이션 사이의 공간 활용 -->
     <main class="flex-1 flex flex-col pt-[100px] pb-[108px]">
-      <!-- 필터 컨트롤 (카드가 있을 때만 표시) -->
-      <div v-if="!isLoading && !error && cards.length > 0" class="px-5 mb-6">
-        <div class="flex justify-center gap-2">
-          <button
-            v-for="filter in ['all', 'active', 'inactive']"
-            :key="filter"
-            @click="changeFilter(filter)"
-            :class="{
-              'bg-brand-primary text-text-inverse': filterState === filter,
-              'bg-base-bg text-subtle-text border border-subtle-border': filterState !== filter,
-            }"
-            class="px-4 py-2 rounded-lg text-sm font-medium transition-colors duration-200 hover:bg-brand-accent hover:text-text-inverse"
-          >
-            {{ getFilterLabel(filter) }}
-          </button>
-        </div>
-      </div>
-
       <!-- 메인 카드 영역 -->
       <div class="flex-1 flex items-center justify-center">
         <!-- 로딩 상태 -->

--- a/src/pages/fancard/MobileTicketPage.vue
+++ b/src/pages/fancard/MobileTicketPage.vue
@@ -21,13 +21,14 @@ const handleClose = () => {
 }
 
 const ticket = ref({
-  imgUrl: '/src/assets/fancard/YeoDanO.svg', // 시연용 이미지
-  title: '여단오 팬미팅 <여단오와 함께하는 특별한 시간>',
-  location: '서울시 강남구 코엑스 컨벤션센터 A홀',
-  date: '1/15',
-  dayOfWeek: '수',
-  time: '19:00',
-  seat: 'A열 5번',
+  imgUrl: null,
+  title: '팬미팅 정보를 불러오는 중...',
+  description: '',
+  location: '',
+  date: '',
+  dayOfWeek: '',
+  time: '',
+  seat: '',
   qrUrl: '/images/qr.png',
 })
 
@@ -52,8 +53,17 @@ const getCurrentUserId = async () => {
 
 // 고유 모바일 티켓 데이터 로드
 const loadUniqueTicketData = async () => {
-  const { reservationId, seatId, meetingId } = route.params
-  if (!reservationId || !seatId || !meetingId) return
+  // params 방식 또는 query 방식 모두 지원
+  const reservationId = route.params.reservationId || route.query.reservationId
+  const seatId = route.params.seatId || route.query.seatId  
+  const meetingId = route.params.meetingId || route.query.fanMeetingId
+  
+  console.log('🎫 loadUniqueTicketData 파라미터:', { reservationId, seatId, meetingId })
+  
+  if (!reservationId || !seatId || !meetingId) {
+    console.warn('⚠️ 필수 파라미터 누락으로 loadUniqueTicketData 스킵')
+    return
+  }
 
   isUniqueTicket.value = true
   isLoadingTicketData.value = true
@@ -62,9 +72,15 @@ const loadUniqueTicketData = async () => {
     const response = await fancardApi.getMobileTicketData(reservationId, seatId, meetingId)
     ticketData.value = response.data
     
+    console.log('🎫 모바일 티켓 API 응답:', response.data)
+    
     // 티켓 정보 업데이트
     if (response.data.reservation) {
-      updateTicketFromReservation(response.data.reservation)
+      updateTicketFromReservation(
+        response.data.reservation,
+        response.data.influencer,
+        response.data.fancardImageUrl
+      )
     }
   } catch (error) {
     console.error('모바일 티켓 데이터 로드 실패:', error)
@@ -75,7 +91,7 @@ const loadUniqueTicketData = async () => {
 }
 
 // 예약 정보로부터 티켓 정보 업데이트
-const updateTicketFromReservation = (reservation) => {
+const updateTicketFromReservation = (reservation, influencer, fancardImageUrl) => {
   if (!reservation) return
 
   const meetingDate = new Date(reservation.meetingDate)
@@ -91,12 +107,22 @@ const updateTicketFromReservation = (reservation) => {
   ticket.value = {
     ...ticket.value,
     title: reservation.meetingTitle || ticket.value.title,
+    description: reservation.meetingDescription || '',
     location: reservation.venueName || ticket.value.location,
     date: dateStr,
     dayOfWeek: dayOfWeek,
     time: timeStr,
     seat: reservation.seatNumber || ticket.value.seat,
+    imgUrl: fancardImageUrl || ticket.value.imgUrl,
+    influencerName: influencer?.influencerName || '',
   }
+  
+  console.log('🎫 티켓 정보 업데이트:', {
+    title: ticket.value.title,
+    description: ticket.value.description,
+    imgUrl: ticket.value.imgUrl,
+    influencerName: ticket.value.influencerName
+  })
 }
 
 // QR 코드 관련 상태
@@ -164,11 +190,21 @@ const generateQrCode = async () => {
 
     console.log('현재 위치:', currentLocation.value) // 디버깅용
 
-    // 고유 티켓인 경우 route params에서, 아니면 query에서 가져오기
-    const reservationId = isUniqueTicket.value ? route.params.reservationId : (route.query.reservationId || 1)
-    const fanMeetingId = isUniqueTicket.value ? route.params.meetingId : (route.query.fanMeetingId || 1)
+    // 사용자 ID 조회
+    const userId = await getCurrentUserId()
     
-    const userId = await getCurrentUserId() // 사용자 ID 조회
+    // 고유 티켓인 경우 route params에서, 아니면 query에서 가져오기
+    const reservationId = isUniqueTicket.value ? route.params.reservationId : route.query.reservationId
+    const fanMeetingId = isUniqueTicket.value ? route.params.meetingId : route.query.fanMeetingId
+    
+    // 필수 파라미터 검증
+    if (!reservationId || !fanMeetingId) {
+      console.error('❌ 필수 파라미터 누락:', { reservationId, fanMeetingId })
+      locationError.value = '예약 정보가 없습니다. 팬카드 상세 페이지에서 다시 시도해주세요.'
+      return
+    }
+    
+    console.log('🎫 QR 생성 파라미터:', { reservationId, fanMeetingId, userId })
     
     const qrRequest = {
       reservationId: parseInt(reservationId),
@@ -286,9 +322,10 @@ onUnmounted(() => {
         >
           이미지를 불러올 수 없습니다
         </div>
-        <div class="mt-5">
-          <p class="font-bold text-xl">{{ ticket.title }}</p>
-          <div class="text-subtle-text text-base flex items-center gap-1">
+        <div class="mt-5 text-center">
+          <h2 class="font-bold text-xl mb-2">{{ ticket.title }}</h2>
+          <p v-if="ticket.description" class="text-base text-black mb-3">{{ ticket.description }}</p>
+          <div class="text-subtle-text text-base flex items-center justify-center gap-1">
             <img src="/src/assets/common/map-pin.svg" alt="" />
             <span>{{ ticket.location }}</span>
           </div>
@@ -306,13 +343,18 @@ onUnmounted(() => {
       </div>
 
       <div class="p-7 flex justify-between items-start">
-        <div class="space-y-5">
-          <p class="text-lg font-medium">{{ ticket.date }}({{ ticket.dayOfWeek }})</p>
-          <p class="text-3xl font-medium">{{ ticket.time }} ~</p>
-          <div class="flex">
-            <p class="font-normal text-base">일반석(</p>
-            <p class="font-bold">{{ ticket.seat }}</p>
-            <p>)</p>
+        <div class="space-y-3">
+          <div>
+            <p class="text-sm text-subtle-text">날짜</p>
+            <p class="text-lg font-medium">{{ ticket.date }}({{ ticket.dayOfWeek }})</p>
+          </div>
+          <div>
+            <p class="text-sm text-subtle-text">시간</p>
+            <p class="text-2xl font-medium">{{ ticket.time }}</p>
+          </div>
+          <div>
+            <p class="text-sm text-subtle-text">내 좌석</p>
+            <p class="text-lg font-bold text-brand-primary">{{ ticket.seat }}</p>
           </div>
         </div>
 

--- a/src/pages/fancard/MobileTicketPage.vue
+++ b/src/pages/fancard/MobileTicketPage.vue
@@ -193,9 +193,17 @@ const generateQrCode = async () => {
     // 사용자 ID 조회
     const userId = await getCurrentUserId()
     
-    // 고유 티켓인 경우 route params에서, 아니면 query에서 가져오기
-    const reservationId = isUniqueTicket.value ? route.params.reservationId : route.query.reservationId
-    const fanMeetingId = isUniqueTicket.value ? route.params.meetingId : route.query.fanMeetingId
+    // route에서 파라미터 가져오기 (params 또는 query 모두 지원)
+    const reservationId = route.params.reservationId || route.query.reservationId
+    const fanMeetingId = route.params.meetingId || route.params.fanMeetingId || route.query.fanMeetingId
+    
+    console.log('🔍 라우트 파라미터 디버깅:', {
+      'route.params': route.params,
+      'route.query': route.query,
+      'isUniqueTicket': isUniqueTicket.value,
+      'extracted reservationId': reservationId,
+      'extracted fanMeetingId': fanMeetingId
+    })
     
     // 필수 파라미터 검증
     if (!reservationId || !fanMeetingId) {


### PR DESCRIPTION
## 🔖 PR 유형
- [x] ✨ 기능 추가
- [x] 🐛 버그 수정
- [x] ♻️ 리팩토링
- [ ] 🧪 테스트 코드 추가
- [ ] 📄 문서 수정
- [ ] 기타

## 📌 개요
  - 팬카드별 정확한 팬미팅 예약 표시 구현
  - 모바일 티켓 QR 생성 파라미터 누락 문제 해결
  - 사용자별 팬미팅 예약 확인 API 추가


## 🔧 작업 내용
  ### 🎯 팬카드별 예약 표시 정확성 개선
  - 모든 예약 확인에서 특정 인플루언서 예약 확인으로 로직 변경
  - 팬카드별로 해당 인플루언서의 예약만 표시되도록 수정
  - 잘못된 라우팅 문제 해결 (김종국 팬카드 → 김승원빈 티켓 이동 방지)

  ### 📱 모바일 티켓 파라미터 처리 개선
  - 조건부 파라미터 추출을 통합 로직으로 변경
  - params와 query 모든 경우를 지원하도록 개선
  - fanMeetingId, meetingId 등 다양한 파라미터명 지원 추가
  - 디버깅 로그 추가로 파라미터 추출 과정 투명화

  ### 🔧 API 함수 확장
  - `checkAnyUpcomingMeeting` 함수 추가
  - 인플루언서 구분 없이 모든 예약 확인 기능 구현
  - 기존 API와의 호환성 유지


## ✅ 체크리스트
구독 시작, 해지, 상품구매
<img width="373" height="802" alt="image" src="https://github.com/user-attachments/assets/828145cf-bcf4-4618-af39-811d9ab5fefa" />

팬미팅 예매
<img width="364" height="794" alt="image" src="https://github.com/user-attachments/assets/d23a48b7-d3f7-4f7e-ace2-5f4422fed509" />


QR 생성
<img width="372" height="805" alt="image" src="https://github.com/user-attachments/assets/87addb43-62b1-4bda-9626-2c9c707655d5" />


QR 검증
<img width="372" height="805" alt="image" src="https://github.com/user-attachments/assets/8f08dbea-11da-4937-9119-770d95459a7f" />


## 📝 기타 참고 사항
- 주의할 점, 추후 리팩토링 필요성 등

## 📎 관련 이슈
Close #이슈번호